### PR TITLE
add nginx client_max_body_size value

### DIFF
--- a/cli/stubs/valet.conf
+++ b/cli/stubs/valet.conf
@@ -2,6 +2,7 @@ server {
     listen 80 default_server;
     root /;
     charset utf-8;
+    client_max_body_size 128M;
 
     location /static/ {
         internal;


### PR DESCRIPTION
The default value is too low at 1MB resulting in `413 Request Entity Too Large`. For a development environment setting this way higher shouldn't be a problem