### PR TITLE
Updated getPHPVersion() from cli/Valet/PackageManagers/Apt.php to include digit regex.

### DIFF
--- a/cli/Valet/PackageManagers/Apt.php
+++ b/cli/Valet/PackageManagers/Apt.php
@@ -92,7 +92,7 @@ class Apt implements PackageManager
      */
     function getPHPVersion()
     {
-        $packages = $this->packages('php*cli');
+        $packages = $this->packages('php[0-9]*cli');
 
         return explode('php', strtok($packages[0], '-'))[1];
     }


### PR DESCRIPTION
for `dpkg -l 'php*cli' | grep '^ii' | sed 's_  _\\t_g' | cut -f 2` -> output
```
ii\tphp-cli\t\t\t\t1:7.0+35ubuntu6\t\t\t\t all\t\t\t\t\tcommand-line interpreter for the PHP scripting language (default)
ii\tphp-horde-cli\t2.0.6-3build1\t\t\t\t\t all\t\t\t\t\tHorde Command Line Interface API
ii\tphp7.0-cli\t\t 7.0.13-0ubuntu0.16.04.1 amd64\t\t\t\tcommand-line interpreter for the PHP scripting language

```
so I included digit regex
 `dpkg -l 'php[0-9]*cli' | grep '^ii' | sed 's_  _\\t_g' | cut -f 2`
`ii\tphp7.0-cli\t\t 7.0.13-0ubuntu0.16.04.1 amd64\t\t\t\tcommand-line interpreter for the PHP scripting language`
