### PR TITLE
$query_string is not needed in nginx rewrite (#23)

### DIFF
--- a/cli/stubs/valet.conf
+++ b/cli/stubs/valet.conf
@@ -11,7 +11,7 @@ server {
     }
 
     location / {
-        rewrite ^ VALET_SERVER_PATH?$query_string last;
+        rewrite ^ VALET_SERVER_PATH last;
     }
 
     location = /favicon.ico { access_log off; log_not_found off; }

--- a/tests/NginxTest.php
+++ b/tests/NginxTest.php
@@ -79,7 +79,7 @@ class NginxTest extends TestCase
 
         $files->shouldReceive('putAsUser')->andReturnUsing(function ($path, $contents) {
             $this->assertSame('/etc/nginx/sites-available/valet.conf', $path);
-            $this->assertTrue(strpos($contents, 'rewrite ^ '.VALET_SERVER_PATH.'?$query_string last') !== false);
+            $this->assertTrue(strpos($contents, 'rewrite ^ '.VALET_SERVER_PATH.' last') !== false);
             $this->assertTrue(strpos($contents, 'error_page 404 '.VALET_SERVER_PATH) !== false);
             $this->assertTrue(strpos($contents, 'fastcgi_index '.VALET_SERVER_PATH) !== false);
             $this->assertTrue(strpos($contents, 'fastcgi_param SCRIPT_FILENAME '.VALET_SERVER_PATH) !== false);


### PR DESCRIPTION
Hello,

Fixes : https://github.com/cpriego/valet-linux/issues/23