### PR TITLE
Updated version number.

### DIFF
--- a/cli/valet.php
+++ b/cli/valet.php
@@ -18,7 +18,7 @@ use Illuminate\Container\Container;
  */
 Container::setInstance(new Container);
 
-$version = '2.0.9';
+$version = '2.0.10';
 
 $app = new Application('Valet', $version);
 


### PR DESCRIPTION
The package's actual version is 2.0.10 but the `$version` var was still set to 2.0.9. This caused incorrect functionality for `valet on-latest-version` command.