### PR TITLE
Sha256 for certs to fix weak-cert-signature in Chrome

### DIFF
--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -208,7 +208,7 @@ class Site
         $this->createSigningRequest($url, $keyPath, $csrPath);
 
         $this->cli->runAsUser(sprintf(
-            'openssl x509 -req -days 365 -in %s -signkey %s -out %s', $csrPath, $keyPath, $crtPath
+            'openssl x509 -req -sha256 -days 365 -in %s -signkey %s -out %s', $csrPath, $keyPath, $crtPath
         ));
 
         $this->trustCertificate($crtPath, $url);


### PR DESCRIPTION
This will fix the message 'NET::ERR_CERT_WEAK_SIGNATURE_ALGORITHM' in Google Chrome