### PR TITLE
Added support for OpenSSL-SAN in Chrome 58+

### DIFF
--- a/cli/stubs/openssl.conf
+++ b/cli/stubs/openssl.conf
@@ -1,0 +1,21 @@
+[req]
+distinguished_name = req_distinguished_name
+req_extensions = v3_req
+
+[req_distinguished_name]
+countryName = Country Name (2 letter code)
+countryName_default = US
+stateOrProvinceName = State or Province Name (full name)
+stateOrProvinceName_default = MN
+localityName = Locality Name (eg, city)
+localityName_default = Minneapolis
+organizationalUnitName	= Organizational Unit Name (eg, section)
+organizationalUnitName_default	= Domain Control Validated
+commonName = Internet Widgits Ltd
+commonName_max	= 64
+
+[ v3_req ]
+subjectAltName = @alt_names
+
+[alt_names]
+DNS.1 = VALET_DOMAIN


### PR DESCRIPTION
This will fix/solve the '[subject CN matching](https://textslashplain.com/2017/03/10/chrome-deprecates-subject-cn-matching/)' (#54) deprecating in Chrome 58+, to add a 'SubjectAltName' for the certificate.

I tested it successfully on Chrome 58.0.3029.81 (64-bit) and Firefox (ESR) 52.1.0 (64-bit)