### PR TITLE
Fix for switching domains/conf files

### DIFF
--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -169,7 +169,7 @@ class Site
     {
         return collect($this->files->scandir($this->certificatesPath()))
             ->map(function ($file) {
-                return str_replace(['.key', '.csr', '.crt'], '', $file);
+                return str_replace(['.key', '.csr', '.crt', '.conf'], '', $file);
             })->unique()->values()->all();
     }
 


### PR DESCRIPTION
Oops, I introduced a small bug after my previous pull-request (#57), which will recreate new *.conf files after switching domains (related to https://github.com/laravel/valet/pull/343)