### PR TITLE
Add PackageKit as a Package manager.

### DIFF
--- a/cli/Valet/PackageManagers/PackageKit.php
+++ b/cli/Valet/PackageManagers/PackageKit.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Valet\PackageManagers;
+
+use DomainException;
+use Valet\CommandLine;
+use Valet\Contracts\PackageManager;
+
+class PackageKit implements PackageManager
+{
+    public $cli;
+
+    /**
+     * Create a new PackageKit instance.
+     *
+     * @param  CommandLine  $cli
+     * @return void
+     */
+    public function __construct(CommandLine $cli)
+    {
+        $this->cli = $cli;
+    }
+
+    /**
+     * Get array of installed packages
+     *
+     * @param  string  $package
+     * @return array
+     */
+    public function packages($package)
+    {
+        $query = "pkcon search {$package} | grep '^In' | sed 's/\s\+/ /g' | cut -d' ' -f2 | sed 's/-[0-9].*//'";
+
+        return explode(PHP_EOL, $this->cli->run($query));
+    }
+
+    /**
+     * Determine if the given package is installed.
+     *
+     * @param  string $package
+     * @return bool
+     */
+    public function installed($package)
+    {
+        return in_array($package, $this->packages($package));
+    }
+
+    /**
+     * Ensure that the given package is installed.
+     *
+     * @param  string $package
+     * @return void
+     */
+    public function ensureInstalled($package)
+    {
+        if (! $this->installed($package)) {
+            $this->installOrFail($package);
+        }
+    }
+
+    /**
+     * Install the given package and throw an exception on failure.
+     *
+     * @param  string $package
+     * @return void
+     */
+    public function installOrFail($package)
+    {
+        output('<info>['.$package.'] is not installed, installing it now via PackageKit...</info> 🍻');
+
+        $this->cli->run(trim('pkcon install -y '.$package), function ($exitCode, $errorOutput) use ($package) {
+            output($errorOutput);
+
+            throw new DomainException('PackageKit was unable to install ['.$package.'].');
+        });
+    }
+
+    /**
+     * Configure package manager on valet install.
+     *
+     * @return void
+     */
+    public function setup()
+    {
+        // Nothing to do
+    }
+
+    /**
+     * Restart dnsmasq in Ubuntu.
+     */
+    public function dnsmasqRestart($sm)
+    {
+        $sm->restart(['network-manager']);
+
+        $version = trim($this->cli->run('cat /etc/*release | grep DISTRIB_RELEASE | cut -d\= -f2'));
+
+        if ($version === '17.04') {
+            $sm->enable('systemd-resolved');
+            $sm->restart('systemd-resolved');
+        }
+    }
+
+    /**
+     * Determine if package manager is available on the system.
+     *
+     * @return bool
+     */
+    public function isAvailable()
+    {
+        try {
+            $output = $this->cli->run('which pkcon', function ($exitCode, $output) {
+                throw new DomainException('PackageKit not available');
+            });
+
+            return $output != '';
+        } catch (DomainException $e) {
+            return false;
+        }
+    }
+}

--- a/cli/Valet/Valet.php
+++ b/cli/Valet/Valet.php
@@ -120,11 +120,11 @@ class Valet
     public function getAvailablePackageManager()
     {
         return collect([
-            PackageKit::class,
             Apt::class,
             Dnf::class,
             Pacman::class,
             Yum::class,
+            PackageKit::class
         ])->first(function ($pm) {
             return resolve($pm)->isAvailable();
         }, function () {

--- a/cli/Valet/Valet.php
+++ b/cli/Valet/Valet.php
@@ -8,10 +8,11 @@ use Valet\Contracts\PackageManager;
 use Valet\Contracts\ServiceManager;
 use Valet\PackageManagers\Apt;
 use Valet\PackageManagers\Dnf;
+use Valet\PackageManagers\PackageKit;
 use Valet\PackageManagers\Pacman;
 use Valet\PackageManagers\Yum;
-use Valet\ServiceManagers\Systemd;
 use Valet\ServiceManagers\LinuxService;
+use Valet\ServiceManagers\Systemd;
 
 class Valet
 {
@@ -119,6 +120,7 @@ class Valet
     public function getAvailablePackageManager()
     {
         return collect([
+            PackageKit::class,
             Apt::class,
             Dnf::class,
             Pacman::class,

--- a/tests/Integration/PackageKitTest.php
+++ b/tests/Integration/PackageKitTest.php
@@ -1,0 +1,80 @@
+<?php
+
+use Valet\CommandLine;
+use Valet\PackageManagers\PackageKit;
+use Illuminate\Container\Container;
+use PHPUnit\Framework\TestCase;
+
+class PackageKitTest extends TestCase
+{
+    public function setUp()
+    {
+        $_SERVER['SUDO_USER'] = user();
+
+        Container::setInstance(new Container);
+    }
+
+
+    public function tearDown()
+    {
+        Mockery::close();
+    }
+
+
+    public function test_PackageKit_can_be_resolved_from_container()
+    {
+        $this->assertInstanceOf(PackageKit::class, resolve(PackageKit::class));
+    }
+
+
+    public function test_installed_returns_true_when_given_formula_is_installed()
+    {
+        $cli = Mockery::mock(CommandLine::class);
+        $cli->shouldReceive('run')->once()
+            ->with("pkcon search php7.0-cli | grep '^In' | sed 's/\s\+/ /g' | cut -d' ' -f2 | sed 's/-[0-9].*//'")
+            ->andReturn('php7.0-cli');
+        swap(CommandLine::class, $cli);
+        $this->assertTrue(resolve(PackageKit::class)->installed('php7.0-cli'));
+    }
+
+
+    public function test_installed_returns_false_when_given_formula_is_not_installed()
+    {
+        $cli = Mockery::mock(CommandLine::class);
+        $cli->shouldReceive('run')->once()
+            ->with("pkcon search php7.0-cli | grep '^In' | sed 's/\s\+/ /g' | cut -d' ' -f2 | sed 's/-[0-9].*//'")
+            ->andReturn('');
+        swap(CommandLine::class, $cli);
+        $this->assertFalse(resolve(PackageKit::class)->installed('php7.0-cli'));
+
+        $cli = Mockery::mock(CommandLine::class);
+        $cli->shouldReceive('run')->once()
+            ->with("pkcon search php7.0-cli | grep '^In' | sed 's/\s\+/ /g' | cut -d' ' -f2 | sed 's/-[0-9].*//'")
+            ->andReturn('php7.0-mcrypt');
+        swap(CommandLine::class, $cli);
+        $this->assertFalse(resolve(PackageKit::class)->installed('php7.0-cli'));
+    }
+
+
+    public function test_install_or_fail_will_install_packages()
+    {
+        $cli = Mockery::mock(CommandLine::class);
+        $cli->shouldReceive('run')->once()->with('pkcon install -y dnsmasq', Mockery::type('Closure'));
+        swap(CommandLine::class, $cli);
+        resolve(PackageKit::class)->installOrFail('dnsmasq');
+    }
+
+
+    /**
+     * @expectedException DomainException
+     */
+    public function test_install_or_fail_throws_exception_on_failure()
+    {
+        $cli = Mockery::mock(CommandLine::class);
+        $cli->shouldReceive('run')->andReturnUsing(function ($command, $onError) {
+            $onError(1, 'test error ouput');
+        });
+        swap(CommandLine::class, $cli);
+        resolve(PackageKit::class)->installOrFail('dnsmasq');
+    }
+}


### PR DESCRIPTION
PackageKit attempts to create a cross-distro package manager and is supported on most popular ones.
While the distro specific package manager is probably preferred in most cases, having PackageKit as a fallback can be useful.

Especially on those that do not yet have support, (OpenSuSE, Mageia, Sabayon pops my mind.. :)).

Link to PackageKit: https://www.freedesktop.org/software/PackageKit