### PR TITLE
Bail out when PHP is not installed.

### DIFF
--- a/valet
+++ b/valet
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+if ! [ -x "$(command -v php)" ]; then
+        echo "Please install PHP.";
+        exit 1;
+fi
+
 SOURCE="${BASH_SOURCE[0]}"
 SUDOCMDS="uninstall install start restart stop unsecure secure"
 HOMEPATH=$HOME


### PR DESCRIPTION
I believe this is the best solution, as detecting and handling installing PHP without the running the package manager class, would quickly get messy.