### PR TITLE
Sync ValetDrivers with upstream, add support for LocalValetDriver

### DIFF
--- a/cli/drivers/CraftValetDriver.php
+++ b/cli/drivers/CraftValetDriver.php
@@ -12,7 +12,18 @@ class CraftValetDriver extends ValetDriver
      */
     public function serves($sitePath, $siteName, $uri)
     {
-        return is_dir($sitePath.'/craft');
+        return file_exists($sitePath.'/craft');
+    }
+
+    /**
+     * Determine the name of the directory where the front controller lives.
+     *
+     * @param  string  $sitePath
+     * @return string
+     */
+    public function frontControllerDirectory($sitePath)
+    {
+        return is_file($sitePath.'/craft') ? 'web' : 'public';
     }
 
     /**
@@ -25,7 +36,9 @@ class CraftValetDriver extends ValetDriver
      */
     public function isStaticFile($sitePath, $siteName, $uri)
     {
-        if ($this->isActualFile($staticFilePath = $sitePath.'/public'.$uri)) {
+        $frontControllerDirectory = $this->frontControllerDirectory($sitePath);
+
+        if ($this->isActualFile($staticFilePath = $sitePath.'/'.$frontControllerDirectory.$uri)) {
             return $staticFilePath;
         }
 
@@ -42,8 +55,10 @@ class CraftValetDriver extends ValetDriver
      */
     public function frontControllerPath($sitePath, $siteName, $uri)
     {
+        $frontControllerDirectory = $this->frontControllerDirectory($sitePath);
+
         // Default index path
-        $indexPath = $sitePath.'/public/index.php';
+        $indexPath = $sitePath.'/'.$frontControllerDirectory.'/index.php';
         $scriptName = '/index.php';
 
         // Check if the first URL segment matches any of the defined locales
@@ -175,6 +190,8 @@ class CraftValetDriver extends ValetDriver
         $_SERVER['SCRIPT_FILENAME'] = $indexPath;
         $_SERVER['SERVER_NAME'] = $_SERVER['HTTP_HOST'];
         $_SERVER['SCRIPT_NAME'] = $scriptName;
+        $_SERVER['PHP_SELF'] = $scriptName;
+        $_SERVER['DOCUMENT_ROOT'] = $sitePath.'/'.$frontControllerDirectory;
 
         return $indexPath;
     }

--- a/cli/drivers/LaravelValetDriver.php
+++ b/cli/drivers/LaravelValetDriver.php
@@ -26,7 +26,8 @@ class LaravelValetDriver extends ValetDriver
      */
     public function isStaticFile($sitePath, $siteName, $uri)
     {
-        if (file_exists($staticFilePath = $sitePath.'/public'.$uri)) {
+        if (file_exists($staticFilePath = $sitePath.'/public'.$uri)
+           && is_file($staticFilePath)) {
             return $staticFilePath;
         }
 
@@ -53,6 +54,11 @@ class LaravelValetDriver extends ValetDriver
      */
     public function frontControllerPath($sitePath, $siteName, $uri)
     {
+        // Shortcut for getting the "local" hostname as the HTTP_HOST
+        if (isset($_SERVER['HTTP_X_ORIGINAL_HOST'], $_SERVER['HTTP_X_FORWARDED_HOST'])) {
+            $_SERVER['HTTP_HOST'] = $_SERVER['HTTP_X_FORWARDED_HOST'];
+        }
+        
         return $sitePath.'/public/index.php';
     }
 }

--- a/cli/drivers/Magento2ValetDriver.php
+++ b/cli/drivers/Magento2ValetDriver.php
@@ -1,0 +1,151 @@
+<?php
+
+class Magento2ValetDriver extends ValetDriver
+{
+
+    /**
+     * Holds the MAGE_MODE from app/etc/config.php or $ENV
+     *
+     * @var string
+     */
+    private $mageMode;
+
+    /**
+     * Determine if the driver serves the request.
+     *
+     * @param  string $sitePath
+     * @param  string $siteName
+     * @param  string $uri
+     * @return boolean
+     */
+    public function serves($sitePath, $siteName, $uri)
+    {
+        return file_exists($sitePath . '/bin/magento') && file_exists($sitePath . '/pub/index.php');
+    }
+
+    /**
+     * Determine if the incoming request is for a static file.
+     *
+     * @param  string $sitePath
+     * @param  string $siteName
+     * @param  string $uri
+     * @return string|false
+     */
+    public function isStaticFile($sitePath, $siteName, $uri)
+    {
+        $this->checkMageMode($sitePath);
+
+        $uri = $this->handleForVersions($uri);
+        $route = parse_url(substr($uri, 1))['path'];
+
+        $pub = '';
+        if ('developer' === $this->mageMode) {
+            $pub = 'pub/';
+        }
+
+        if (!$this->isPubDirectory($sitePath, $route, $pub)) {
+            return false;
+        }
+
+        $magentoPackagePubDir = $sitePath;
+        if ('developer' !== $this->mageMode) {
+            $magentoPackagePubDir .= '/pub';
+        }
+
+        $file = $magentoPackagePubDir . '/' . $route;
+
+        if (file_exists($file)) {
+            return $magentoPackagePubDir . $uri;
+        }
+
+        if (strpos($route, $pub . 'static/') === 0) {
+            $route = preg_replace('#' . $pub . 'static/#', '', $route, 1);
+            $_GET['resource'] = $route;
+            include $magentoPackagePubDir . '/' . $pub . 'static.php';
+            exit;
+        }
+
+        if (strpos($route, $pub . 'media/') === 0) {
+            include $magentoPackagePubDir . '/' . $pub . 'get.php';
+            exit;
+        }
+
+        return false;
+    }
+
+    /**
+     * Rewrite URLs that look like "versions12345/" to remove
+     * the versions12345/ part
+     *
+     * @param  string $route
+     */
+    private function handleForVersions($route)
+    {
+        return preg_replace('/version\d*\//', '', $route);
+    }
+
+    /**
+     * Determine the current MAGE_MODE
+     *
+     * @param  string $sitePath
+     */
+    private function checkMageMode($sitePath)
+    {
+        if (null !== $this->mageMode) {
+            // We have already figure out mode, no need to check it again
+            return;
+        }
+        if (!file_exists($sitePath . '/index.php')) {
+            $this->mageMode = 'production'; // Can't use developer mode without index.php in project root
+            return;
+        }
+        $mageConfig = [];
+        if (file_exists($sitePath . '/app/etc/env.php')) {
+            $mageConfig = require $sitePath . '/app/etc/env.php';
+        }
+        if (array_key_exists('MAGE_MODE', $mageConfig)) {
+            $this->mageMode = $mageConfig['MAGE_MODE'];
+        }
+    }
+
+    /**
+     * Checks to see if route is referencing any directory inside pub. This is a dynamic check so that if any new
+     * directories are added to pub this driver will not need to be updated.
+     *
+     * @param string $sitePath
+     * @param string $route
+     * @param string $pub
+     * @return bool
+     */
+    private function isPubDirectory($sitePath, $route, $pub = '')
+    {
+        $sitePath .= '/pub/';
+        $dirs = glob($sitePath . '*', GLOB_ONLYDIR);
+
+        $dirs = str_replace($sitePath, '', $dirs);
+        foreach ($dirs as $dir) {
+            if (strpos($route, $pub . $dir . '/') === 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Get the fully resolved path to the application's front controller.
+     *
+     * @param  string $sitePath
+     * @param  string $siteName
+     * @param  string $uri
+     * @return string
+     */
+    public function frontControllerPath($sitePath, $siteName, $uri)
+    {
+        $this->checkMageMode($sitePath);
+
+        if ('developer' === $this->mageMode) {
+            return $sitePath . '/index.php';
+        }
+        return $sitePath . '/pub/index.php';
+    }
+}

--- a/cli/drivers/NeosValetDriver.php
+++ b/cli/drivers/NeosValetDriver.php
@@ -1,6 +1,6 @@
 <?php
 
-class CakeValetDriver extends ValetDriver
+class NeosValetDriver extends ValetDriver
 {
     /**
      * Determine if the driver serves the request.
@@ -12,7 +12,7 @@ class CakeValetDriver extends ValetDriver
      */
     public function serves($sitePath, $siteName, $uri)
     {
-        return file_exists($sitePath.'/bin/cake');
+        return file_exists($sitePath.'/flow') && is_dir($sitePath.'/Web');
     }
 
     /**
@@ -25,10 +25,9 @@ class CakeValetDriver extends ValetDriver
      */
     public function isStaticFile($sitePath, $siteName, $uri)
     {
-        if ($this->isActualFile($staticFilePath = $sitePath.'/webroot/'.$uri)) {
+        if ($this->isActualFile($staticFilePath = $sitePath.'/Web'.$uri)) {
             return $staticFilePath;
         }
-
         return false;
     }
 
@@ -42,11 +41,10 @@ class CakeValetDriver extends ValetDriver
      */
     public function frontControllerPath($sitePath, $siteName, $uri)
     {
-        $_SERVER['DOCUMENT_ROOT'] = $sitePath.'/webroot';
-        $_SERVER['SCRIPT_FILENAME'] = $sitePath.'/webroot/index.php';
+        putenv('FLOW_CONTEXT=Development');
+        putenv('FLOW_REWRITEURLS=1');
+        $_SERVER['SCRIPT_FILENAME'] = $sitePath.'/Web/index.php';
         $_SERVER['SCRIPT_NAME'] = '/index.php';
-        $_SERVER['PHP_SELF'] = '/index.php';
-
-        return $sitePath.'/webroot/index.php';
+        return $sitePath.'/Web/index.php';
     }
 }

--- a/cli/drivers/SymfonyValetDriver.php
+++ b/cli/drivers/SymfonyValetDriver.php
@@ -13,7 +13,9 @@ class SymfonyValetDriver extends ValetDriver
     public function serves($sitePath, $siteName, $uri)
     {
         return (file_exists($sitePath.'/web/app_dev.php') || file_exists($sitePath.'/web/app.php')) &&
-               (file_exists($sitePath.'/app/AppKernel.php'));
+               (file_exists($sitePath.'/app/AppKernel.php')) || (file_exists($sitePath.'/web/index.php')) &&
+               (file_exists($sitePath.'/src/Kernel.php'))
+            ;
     }
 
     /**
@@ -46,6 +48,8 @@ class SymfonyValetDriver extends ValetDriver
         if (file_exists($frontControllerPath = $sitePath.'/web/app_dev.php')) {
             return $frontControllerPath;
         } elseif (file_exists($frontControllerPath = $sitePath.'/web/app.php')) {
+            return $frontControllerPath;
+        } elseif (file_exists($frontControllerPath = $sitePath.'/web/index.php')) {
             return $frontControllerPath;
         }
     }

--- a/cli/drivers/Typo3ValetDriver.php
+++ b/cli/drivers/Typo3ValetDriver.php
@@ -1,0 +1,185 @@
+<?php
+
+/**
+ * This driver serves TYPO3 instances (version 7.0 and up). It activates, if it
+ * finds the characteristic typo3/ folder in the document root, serves both
+ * frontend and backend scripts and prevents access to private resources.
+ */
+class Typo3ValetDriver extends ValetDriver
+{
+    /*
+    |--------------------------------------------------------------------------
+    | Document Root Subdirectory
+    |--------------------------------------------------------------------------
+    |
+    | This subdirectory contains the public server resources, such as the
+    | index.php, the typo3 and fileadmin system directories. Change it
+    | to '', if you don't use a subdirectory but valet link directly.
+    |
+    */
+    protected $documentRoot = '/web';
+
+    /*
+    |--------------------------------------------------------------------------
+    | Forbidden URI Patterns
+    |--------------------------------------------------------------------------
+    |
+    | All of these patterns won't be accessible from your web server. Instead,
+    | the server will throw a 403 forbidden response, if you try to access
+    | these files via the HTTP layer. Use regex syntax here and escape @.
+    |
+    */
+    protected $forbiddenUriPatterns = [
+        '_(recycler|temp)_/',
+        '^/(typo3conf/ext|typo3/sysext|typo3/ext)/[^/]+/(Resources/Private|Tests)/',
+        '^/typo3/.+\.map$',
+        '^/typo3temp/var/',
+        '\.(htaccess|gitkeep|gitignore)$',
+    ];
+
+    /**
+     * Determine if the driver serves the request. For TYPO3, this is the
+     * case, if a folder called "typo3" is present in the document root.
+     *
+     * @param  string  $sitePath
+     * @param  string  $siteName
+     * @param  string  $uri
+     * @return bool
+     */
+    public function serves($sitePath, $siteName, $uri)
+    {
+        $typo3Dir = $sitePath . $this->documentRoot . '/typo3';
+        return file_exists($typo3Dir) && is_dir($typo3Dir);
+    }
+
+    /**
+     * Determine if the incoming request is for a static file. That is, it is
+     * no PHP script file and the URI points to a valid file (no folder) on
+     * the disk. Access to those static files will be authorized.
+     *
+     * @param  string  $sitePath
+     * @param  string  $siteName
+     * @param  string  $uri
+     * @return string|false
+     */
+    public function isStaticFile($sitePath, $siteName, $uri)
+    {
+        // May the file contains a cache busting version string like filename.12345678.css
+        // If that is the case, the file cannot be found on disk, so remove the version
+        // identifier before retrying below.
+        if (!$this->isActualFile($filePath = $sitePath . $this->documentRoot . $uri)) {
+            $uri = preg_replace("@^(.+)\.(\d+)\.(js|css|png|jpg|gif|gzip)$@", "$1.$3", $uri);
+        }
+
+        // Now that any possible version string is cleared from the filename, the resulting
+        // URI should be a valid file on disc. So assemble the absolut file name with the
+        // same schema as above and if it exists, authorize access and return its path.
+        if ($this->isActualFile($filePath = $sitePath . $this->documentRoot . $uri)) {
+            return $this->isAccessAuthorized($uri) ? $filePath : false;
+        }
+
+        // This file cannot be found in the current project and thus cannot be served.
+        return false;
+    }
+
+    /**
+     * Determines if the given URI is blacklisted so that access is prevented.
+     *
+     * @param string $uri
+     * @return boolean
+     */
+    private function isAccessAuthorized($uri)
+    {
+        foreach ($this->forbiddenUriPatterns as $forbiddenUriPattern) {
+            if (preg_match("@$forbiddenUriPattern@", $uri)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Get the fully resolved path to the application's front controller.
+     * This can be the currently requested PHP script, a folder that
+     * contains an index.php or the global index.php otherwise.
+     *
+     * @param  string  $sitePath
+     * @param  string  $siteName
+     * @param  string  $uri
+     * @return string
+     */
+    public function frontControllerPath($sitePath, $siteName, $uri)
+    {
+        // without modifying the URI, redirect if necessary
+        $this->handleRedirectBackendShorthandUris($uri);
+
+        // from now on, remove trailing / for convenience for all the following join operations
+        $uri = rtrim($uri, '/');
+
+        // try to find the responsible script file for the requested folder / script URI
+        if (file_exists($absoluteFilePath = $sitePath . $this->documentRoot . $uri)) {
+            if (is_dir($absoluteFilePath)) {
+                if (file_exists($absoluteFilePath . '/index.php')) {
+                    // this folder can be served by index.php
+                    return $this->serveScript($sitePath, $siteName, $uri . '/index.php');
+                }
+
+                if (file_exists($absoluteFilePath . '/index.html')) {
+                    // this folder can be served by index.html
+                    return $absoluteFilePath . '/index.html';
+                }
+            } elseif (pathinfo($absoluteFilePath, PATHINFO_EXTENSION) === 'php') {
+                // this file can be served directly
+                return $this->serveScript($sitePath, $siteName, $uri);
+            }
+        }
+
+        // the global index.php will handle all other cases
+        return $this->serveScript($sitePath, $siteName, '/index.php');
+    }
+
+    /**
+     * Direct access to installtool via domain.dev/typo3/install/ will be redirected to
+     * sysext install script. domain.dev/typo3 will be redirected to /typo3/, because
+     * the generated JavaScript URIs on the login screen would be broken on /typo3.
+     *
+     * @param string $uri
+     */
+    private function handleRedirectBackendShorthandUris($uri)
+    {
+        if (rtrim($uri, '/') === '/typo3/install') {
+            header('Location: /typo3/sysext/install/Start/Install.php');
+            die();
+        }
+
+        if ($uri === '/typo3') {
+            header('Location: /typo3/');
+            die();
+        }
+    }
+
+    /**
+     * Configures the $_SERVER globals for serving the script at
+     * the specified URI and returns it absolute file path.
+     *
+     * @param  string  $sitePath
+     * @param  string  $siteName
+     * @param  string  $uri
+     * @param  string  $script
+     * @return string
+     */
+    private function serveScript($sitePath, $siteName, $uri)
+    {
+        $docroot = $sitePath . $this->documentRoot;
+        $abspath = $docroot . $uri;
+
+        $_SERVER['SERVER_NAME'] = $siteName . '.dev';
+        $_SERVER['DOCUMENT_ROOT'] = $docroot;
+        $_SERVER['DOCUMENT_URI'] = $uri;
+        $_SERVER['SCRIPT_FILENAME'] = $abspath;
+        $_SERVER['SCRIPT_NAME'] = $uri;
+        $_SERVER['PHP_SELF'] = $uri;
+
+        return $abspath;
+    }
+}

--- a/cli/drivers/ValetDriver.php
+++ b/cli/drivers/ValetDriver.php
@@ -42,12 +42,19 @@ abstract class ValetDriver
      */
     public static function assign($sitePath, $siteName, $uri)
     {
-        $drivers = static::driversIn(VALET_HOME_PATH.'/Drivers');
+        $drivers = [];
+
+        if ($customSiteDriver = static::customSiteDriver($sitePath)) {
+            $drivers[] = $customSiteDriver;
+        }
+
+        $drivers = array_merge($drivers, static::driversIn(VALET_HOME_PATH.'/Drivers'));
 
         $drivers[] = 'LaravelValetDriver';
 
         $drivers[] = 'WordPressValetDriver';
         $drivers[] = 'BedrockValetDriver';
+        $drivers[] = 'ContaoValetDriver';
         $drivers[] = 'SymfonyValetDriver';
         $drivers[] = 'CraftValetDriver';
         $drivers[] = 'StatamicValetDriver';
@@ -56,11 +63,13 @@ abstract class ValetDriver
         $drivers[] = 'SculpinValetDriver';
         $drivers[] = 'JigsawValetDriver';
         $drivers[] = 'KirbyValetDriver';
-        $drivers[] = 'ContaoValetDriver';
         $drivers[] = 'KatanaValetDriver';
         $drivers[] = 'JoomlaValetDriver';
         $drivers[] = 'DrupalValetDriver';
         $drivers[] = 'Concrete5ValetDriver';
+        $drivers[] = 'Typo3ValetDriver';
+        $drivers[] = 'NeosValetDriver';
+        $drivers[] = 'Magento2ValetDriver';
 
         $drivers[] = 'BasicValetDriver';
 
@@ -71,6 +80,23 @@ abstract class ValetDriver
                 return $driver;
             }
         }
+    }
+
+    /**
+     * Get the custom driver class from the site path, if one exists.
+     *
+     * @param  string  $sitePath
+     * @return string
+     */
+    public static function customSiteDriver($sitePath)
+    {
+        if (! file_exists($sitePath.'/LocalValetDriver.php')) {
+            return;
+        }
+
+        require_once $sitePath.'/LocalValetDriver.php';
+
+        return 'LocalValetDriver';
     }
 
     /**

--- a/cli/drivers/require.php
+++ b/cli/drivers/require.php
@@ -25,3 +25,6 @@ require_once __DIR__.'/CakeValetDriver.php';
 require_once __DIR__.'/JoomlaValetDriver.php';
 require_once __DIR__.'/DrupalValetDriver.php';
 require_once __DIR__.'/Concrete5ValetDriver.php';
+require_once __DIR__.'/Typo3ValetDriver.php';
+require_once __DIR__.'/NeosValetDriver.php';
+require_once __DIR__.'/Magento2ValetDriver.php';


### PR DESCRIPTION
There were some useful additions to Valet (specifically Magento, Neos and Typo3 drivers) and updates to existing drivers. I updated the drivers to be in sync with upstream without applying changes that haven't been implemented in valet-linux.

This also adds support for project-specific drivers.