### PR TITLE
added restart method

### DIFF
--- a/cli/Valet/DnsMasq.php
+++ b/cli/Valet/DnsMasq.php
@@ -35,6 +35,16 @@ class DnsMasq
     }
 
     /**
+     * Restart the DNS process.
+     *
+     * @return void
+     */
+    public function restart()
+    {
+        $this->pm->dnsmasqRestart($this->sm);
+    }
+
+    /**
      * Install and configure DnsMasq.
      *
      * @return void
@@ -44,7 +54,7 @@ class DnsMasq
         $this->dnsmasqSetup();
         $this->fixResolved();
         $this->createCustomConfigFile('dev');
-        $this->pm->dnsmasqRestart($this->sm);
+        $this->restart();
     }
 
     /**
@@ -92,7 +102,7 @@ class DnsMasq
     {
         $this->fixResolved();
         $this->createCustomConfigFile($newDomain);
-        $this->pm->dnsmasqRestart($this->sm);
+        $this->restart();
     }
 
     /**
@@ -106,6 +116,6 @@ class DnsMasq
         $this->files->unlink($this->nmConfigPath);
         $this->files->restore($this->resolvedConfigPath);
 
-        $this->pm->dnsmasqRestart($this->sm);
+        $this->restart();
     }
 }


### PR DESCRIPTION
When i'm trying to `valet update`: 
```
PHP Warning:  call_user_func_array() expects parameter 1 to be a valid callback, class 'Valet\DnsMasq' does not have a method 'restart' in .../composer/vendor/cpriego/valet-linux/cli/includes/facades.php on line 28
```

This PR added restart method to DnsMasq class