### PR TITLE
Vagrant Testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -111,4 +111,4 @@ script:
   - if [[ -n $distro ]]; then docker exec -it $CONTAINER_ID /prepare.sh; fi
 
   # Run functional tests
-  - if [[ -n $distro ]]; then docker exec -it -u valet $CONTAINER_ID /workspace/tests/Functional/run.sh; fi
+  - if [[ -n $distro ]]; then docker exec -it -u valet $CONTAINER_ID /workspace/tests/Acceptance/docker.sh; fi

--- a/develop
+++ b/develop
@@ -52,6 +52,15 @@ if [ $# -gt 0 ]; then
           fi
     done
 
+  # Run Acceptance tests against ALL environments in parallel
+  elif [ "$1" == "test-all-parallel" ]; then
+      for DIRECTORY in `find $VAGRANT_FOLDER -maxdepth 1 -type d`; do
+            if [[ "$DIRECTORY" != $VAGRANT_FOLDER ]]; then
+              gnome-terminal --tab \
+                  --command="bash -c \"./develop test ${DIRECTORY##*/} && ./develop down ${DIRECTORY##*/}; read\""
+            fi
+      done
+
   fi
 
 else
@@ -93,5 +102,9 @@ else
   # ./develop test-all
   echo -e "\ttest-all"
   echo -e "\t\tRun Acceptance tests against ALL OSes."
+
+  # ./develop test-all-parallel
+  echo -e "\ttest-all-parallel"
+  echo -e "\t\tRun Acceptance tests against ALL OSes in parellel. Requires gnome-terminal."
 
 fi

--- a/develop
+++ b/develop
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+VAGRANT_FOLDER="./tests/Acceptance/Vagrant"
+
+if [ $# -gt 0 ]; then
+
+  # Spin up given development environment
+  if [ "$1" == "up" ]; then
+    cd "$VAGRANT_FOLDER/$2" && \
+    shift 2 && \
+    VALET_ENVIRONMENT=development vagrant up "$@"
+
+  # SSH into the given development environment
+  elif [ "$1" == "ssh" ]; then
+    cd "$VAGRANT_FOLDER/$2" && \
+    shift 2 && \
+    vagrant ssh "$@"
+
+  # Switch off given development environment
+  elif [ "$1" == "down" ]; then
+    cd "$VAGRANT_FOLDER/$2" && \
+    shift 2 && \
+    vagrant down "$@"
+
+  # Destroy given development environment
+  elif [ "$1" == "destroy" ]; then
+    cd "$VAGRANT_FOLDER/$2" && \
+    shift 2 && \
+    vagrant destroy "$@"
+
+  # Run Acceptance tests against given environment
+  elif [ "$1" == "test" ]; then
+    echo "WIP"
+
+  # Run Acceptance tests against ALL environments
+  elif [ "$1" == "test-all" ]; then
+    echo "WIP"
+
+  fi
+
+else
+  # Display usage
+  echo -e "Usage: ./develop [action] [arguments]\n"
+  echo -e "Available actions:"
+
+  # ./develop up {OS_NAME}
+  echo -e "\tup {OS_NAME}"
+  echo -e "\t\tSpin up a development environment using vagrant and SSH into it."
+  echo -e -n "\t\tAvailable OSes: "
+  for DIRECTORY in `find $VAGRANT_FOLDER -maxdepth 1 -type d`; do
+        if [[ "$DIRECTORY" != $VAGRANT_FOLDER ]]; then
+          echo -e -n "${DIRECTORY##*/} "
+        fi
+  done
+  echo
+
+  # ./develop ssh {OS_NAME}
+  echo -e "\tssh {OS_NAME}"
+  echo -e "\t\tSSH into the given development environment."
+
+  # ./develop down {OS_NAME}
+  echo -e "\tdown {OS_NAME}"
+  echo -e "\t\tSwitch off given development environment. This does NOT destroy the box."
+
+  # ./develop down {OS_NAME}
+  echo -e "\tdestroy {OS_NAME}"
+  echo -e "\t\tDestroy given development environment."
+
+  # ./develop test {OS_NAME}
+  echo -e "\ttest {OS_NAME}"
+  echo -e "\t\tRun Acceptance tests against a given OS."
+
+  # ./develop test-all
+  echo -e "\ttest-all"
+  echo -e "\t\tRun Acceptance tests against ALL OSes."
+
+fi

--- a/develop
+++ b/develop
@@ -32,7 +32,7 @@ if [ $# -gt 0 ]; then
   elif [ "$1" == "destroy-all" ]; then
     for DIRECTORY in `find $VAGRANT_FOLDER -maxdepth 1 -type d`; do
           if [[ "$DIRECTORY" != $VAGRANT_FOLDER ]]; then
-            ./develop destroy ${DIRECTORY##*/}
+            ./develop destroy ${DIRECTORY##*/} -f
           fi
     done
 

--- a/develop
+++ b/develop
@@ -20,7 +20,7 @@ if [ $# -gt 0 ]; then
   elif [ "$1" == "down" ]; then
     cd "$VAGRANT_FOLDER/$2" && \
     shift 2 && \
-    vagrant down "$@"
+    vagrant halt "$@"
 
   # Destroy given development environment
   elif [ "$1" == "destroy" ]; then
@@ -28,13 +28,29 @@ if [ $# -gt 0 ]; then
     shift 2 && \
     vagrant destroy "$@"
 
+  # Destroy all development environments
+  elif [ "$1" == "destroy-all" ]; then
+    for DIRECTORY in `find $VAGRANT_FOLDER -maxdepth 1 -type d`; do
+          if [[ "$DIRECTORY" != $VAGRANT_FOLDER ]]; then
+            ./develop destroy ${DIRECTORY##*/}
+          fi
+    done
+
   # Run Acceptance tests against given environment
   elif [ "$1" == "test" ]; then
-    echo "WIP"
+    ./develop up $2 && \
+    ./develop ssh $2 --command "bash ~/cpriego-valet-linux/tests/Acceptance/vagrant.sh"
 
   # Run Acceptance tests against ALL environments
   elif [ "$1" == "test-all" ]; then
-    echo "WIP"
+    for DIRECTORY in `find $VAGRANT_FOLDER -maxdepth 1 -type d`; do
+          if [[ "$DIRECTORY" != $VAGRANT_FOLDER ]]; then
+            echo -e "\033[44m                                   ${DIRECTORY##*/}                                   \033[0m"
+
+            ./develop test ${DIRECTORY##*/} && \
+            ./develop down ${DIRECTORY##*/}
+          fi
+    done
 
   fi
 
@@ -62,9 +78,13 @@ else
   echo -e "\tdown {OS_NAME}"
   echo -e "\t\tSwitch off given development environment. This does NOT destroy the box."
 
-  # ./develop down {OS_NAME}
+  # ./develop destroy {OS_NAME}
   echo -e "\tdestroy {OS_NAME}"
   echo -e "\t\tDestroy given development environment."
+
+  # ./develop destroy-all
+  echo -e "\tdestroy-all"
+  echo -e "\t\tDestroy all development environments."
 
   # ./develop test {OS_NAME}
   echo -e "\ttest {OS_NAME}"

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -16,6 +16,7 @@
     <groups>
         <exclude>
             <group>functional</group>
+            <group>acceptance</group>
         </exclude>
     </groups>
     <php>

--- a/tests/Acceptance/Vagrant/.gitignore
+++ b/tests/Acceptance/Vagrant/.gitignore
@@ -1,0 +1,2 @@
+*/.vagrant
+*.log

--- a/tests/Acceptance/Vagrant/centos7/Vagrantfile
+++ b/tests/Acceptance/Vagrant/centos7/Vagrantfile
@@ -1,0 +1,13 @@
+Vagrant.configure("2") do |config|
+  config.vm.box = "centos/7"
+
+  config.vm.synced_folder "../../../../", "/home/vagrant/cpriego-valet-linux", type: "rsync"
+
+  config.vm.provision "shell" do |s|
+    s.path = "provision.sh"
+    s.privileged = false
+    s.env = {
+      VALET_ENVIRONMENT: ENV['VALET_ENVIRONMENT'] || "testing"
+    }
+  end
+end

--- a/tests/Acceptance/Vagrant/centos7/provision.sh
+++ b/tests/Acceptance/Vagrant/centos7/provision.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+set -e
+
+# Enable remirepo
+sudo yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+sudo yum -y install http://rpms.remirepo.net/enterprise/remi-release-7.rpm
+sudo yum -y install yum-utils
+sudo yum-config-manager --enable remi-php56
+
+# Install OS Requirements
+sudo yum install -y nss-tools jq xsel
+
+# Install Nginx & PHP
+sudo yum install -y nginx curl zip unzip git \
+              php-fpm php-cli php-mcrypt php-mbstring php-xml php-curl php-posix
+
+# Install Composer
+php -r "readfile('http://getcomposer.org/installer');" | sudo php -- --install-dir=/usr/bin/ --filename=composer
+
+# Remove .composer directory created during installation
+sudo rm -rf ~/.composer
+
+# Configure Composer
+mkdir -p ~/.config/composer
+if [ "$VALET_ENVIRONMENT" == "testing" ]
+then
+  # If we are testing, we mirror the repository
+  # so the shared folder stays untouched
+  echo '{
+    "minimum-stability": "dev",
+    "repositories": [
+      {
+        "type": "path",
+        "url": "/home/vagrant/cpriego-valet-linux",
+        "options": {
+          "symlink": false
+        }
+      }
+    ]
+  }' >> ~/.config/composer/composer.json
+else
+  # If we are developing, we sync the repository with the shared folder
+  echo '{
+    "minimum-stability": "dev",
+    "repositories": [
+      {
+        "type": "path",
+        "url": "/home/vagrant/cpriego-valet-linux"
+      }
+    ]
+  }' >> ~/.config/composer/composer.json
+fi
+
+# Require Valet
+composer global require "cpriego/valet-linux @dev" --no-interaction --no-ansi
+
+# Add Composer bin to PATH
+echo "PATH=\"\$HOME/.config/composer/vendor/bin:\$PATH\"" >> ~/.bashrc
+source ~/.bashrc
+
+# Disable SELinux
+sudo setenforce 0
+sudo sed -i 's/SELINUX=enforcing/SELINUX=permissive/g' /etc/selinux/config

--- a/tests/Acceptance/Vagrant/fedora25/Vagrantfile
+++ b/tests/Acceptance/Vagrant/fedora25/Vagrantfile
@@ -1,0 +1,13 @@
+Vagrant.configure("2") do |config|
+  config.vm.box = "bento/fedora-25"
+
+  config.vm.synced_folder "../../../../", "/home/vagrant/cpriego-valet-linux"
+
+  config.vm.provision "shell" do |s|
+    s.path = "provision.sh"
+    s.privileged = false
+    s.env = {
+      VALET_ENVIRONMENT: ENV['VALET_ENVIRONMENT'] || "testing"
+    }
+  end
+end

--- a/tests/Acceptance/Vagrant/fedora25/provision.sh
+++ b/tests/Acceptance/Vagrant/fedora25/provision.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+set -e
+
+# Install OS Requirements
+sudo dnf install -y nss-tools jq xsel
+
+# Install Nginx & PHP
+sudo dnf install -y nginx curl zip unzip git \
+              php-fpm php-cli php-mcrypt php-mbstring php-xml php-curl php-posix
+
+# Install Composer
+php -r "readfile('http://getcomposer.org/installer');" | sudo php -- --install-dir=/usr/bin/ --filename=composer
+
+# Remove .composer directory created during installation
+sudo rm -rf ~/.composer
+
+# Configure Composer
+mkdir -p ~/.config/composer
+if [ "$VALET_ENVIRONMENT" == "testing" ]
+then
+  # If we are testing, we mirror the repository
+  # so the shared folder stays untouched
+  echo '{
+    "minimum-stability": "dev",
+    "repositories": [
+      {
+        "type": "path",
+        "url": "/home/vagrant/cpriego-valet-linux",
+        "options": {
+          "symlink": false
+        }
+      }
+    ]
+  }' >> ~/.config/composer/composer.json
+else
+  # If we are developing, we sync the repository with the shared folder
+  echo '{
+    "minimum-stability": "dev",
+    "repositories": [
+      {
+        "type": "path",
+        "url": "/home/vagrant/cpriego-valet-linux"
+      }
+    ]
+  }' >> ~/.config/composer/composer.json
+fi
+
+# Require Valet
+composer global require "cpriego/valet-linux @dev" --no-interaction --no-ansi
+
+# Add Composer bin to PATH
+echo "PATH=\"\$HOME/.config/composer/vendor/bin:\$PATH\"" >> ~/.profile
+source ~/.profile

--- a/tests/Acceptance/Vagrant/fedora26/Vagrantfile
+++ b/tests/Acceptance/Vagrant/fedora26/Vagrantfile
@@ -1,0 +1,13 @@
+Vagrant.configure("2") do |config|
+  config.vm.box = "bento/fedora-26"
+
+  config.vm.synced_folder "../../../../", "/home/vagrant/cpriego-valet-linux"
+
+  config.vm.provision "shell" do |s|
+    s.path = "provision.sh"
+    s.privileged = false
+    s.env = {
+      VALET_ENVIRONMENT: ENV['VALET_ENVIRONMENT'] || "testing"
+    }
+  end
+end

--- a/tests/Acceptance/Vagrant/fedora26/provision.sh
+++ b/tests/Acceptance/Vagrant/fedora26/provision.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+set -e
+
+# Install OS Requirements
+sudo dnf install -y nss-tools jq xsel
+
+# Install Nginx & PHP
+sudo dnf install -y nginx curl zip unzip git \
+              php-fpm php-cli php-mcrypt php-mbstring php-xml php-curl php-posix
+
+# Install Composer
+php -r "readfile('http://getcomposer.org/installer');" | sudo php -- --install-dir=/usr/bin/ --filename=composer
+
+# Remove .composer directory created during installation
+sudo rm -rf ~/.composer
+
+# Configure Composer
+mkdir -p ~/.config/composer
+if [ "$VALET_ENVIRONMENT" == "testing" ]
+then
+  # If we are testing, we mirror the repository
+  # so the shared folder stays untouched
+  echo '{
+    "minimum-stability": "dev",
+    "repositories": [
+      {
+        "type": "path",
+        "url": "/home/vagrant/cpriego-valet-linux",
+        "options": {
+          "symlink": false
+        }
+      }
+    ]
+  }' >> ~/.config/composer/composer.json
+else
+  # If we are developing, we sync the repository with the shared folder
+  echo '{
+    "minimum-stability": "dev",
+    "repositories": [
+      {
+        "type": "path",
+        "url": "/home/vagrant/cpriego-valet-linux"
+      }
+    ]
+  }' >> ~/.config/composer/composer.json
+fi
+
+# Require Valet
+composer global require "cpriego/valet-linux @dev" --no-interaction --no-ansi
+
+# Add Composer bin to PATH
+echo "PATH=\"\$HOME/.config/composer/vendor/bin:\$PATH\"" >> ~/.profile
+source ~/.profile

--- a/tests/Acceptance/Vagrant/ubuntu1404/Vagrantfile
+++ b/tests/Acceptance/Vagrant/ubuntu1404/Vagrantfile
@@ -1,0 +1,26 @@
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/trusty64"
+
+  # Increase RAM to 2GB because Composer was going out of memory
+  config.vm.provider "virtualbox" do |vb|
+      vb.customize ["modifyvm", :id, "--memory", "2048"]
+  end
+  ["vmware_fusion", "vmware_workstation"].each do |vmware|
+      config.vm.provider vmware do |v|
+          v.vmx["memsize"] = 2048
+      end
+  end
+  config.vm.provider "parallels" do |v|
+      v.memory = 2048
+  end
+
+  config.vm.synced_folder "../../../../", "/home/vagrant/cpriego-valet-linux"
+
+  config.vm.provision "shell" do |s|
+    s.path = "provision.sh"
+    s.privileged = false
+    s.env = {
+      VALET_ENVIRONMENT: ENV['VALET_ENVIRONMENT'] || "testing"
+    }
+  end
+end

--- a/tests/Acceptance/Vagrant/ubuntu1404/provision.sh
+++ b/tests/Acceptance/Vagrant/ubuntu1404/provision.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+set -e
+
+sudo apt-get update
+
+# Install OS Requirements
+sudo apt-get install -y network-manager libnss3-tools jq xsel
+
+# Add PPAs
+sudo add-apt-repository -y ppa:nginx/stable
+sudo add-apt-repository -y ppa:ondrej/php
+sudo apt-get update
+
+# Install Nginx & PHP
+sudo apt-get install -y --force-yes nginx curl zip unzip git \
+              php5.6-fpm php5.6-cli php5.6-mcrypt php5.6-mbstring php5.6-xml php5.6-curl
+
+# Install Composer
+php -r "readfile('http://getcomposer.org/installer');" | sudo php -- --install-dir=/usr/bin/ --filename=composer
+
+# Remove .composer directory created during installation
+sudo rm -rf ~/.composer
+
+# Configure Composer
+mkdir -p ~/.config/composer
+if [ "$VALET_ENVIRONMENT" == "testing" ]
+then
+  # If we are testing, we mirror the repository
+  # so the shared folder stays untouched
+  echo '{
+    "minimum-stability": "dev",
+    "repositories": [
+      {
+        "type": "path",
+        "url": "/home/vagrant/cpriego-valet-linux",
+        "options": {
+          "symlink": false
+        }
+      }
+    ]
+  }' >> ~/.config/composer/composer.json
+else
+  # If we are developing, we sync the repository with the shared folder
+  echo '{
+    "minimum-stability": "dev",
+    "repositories": [
+      {
+        "type": "path",
+        "url": "/home/vagrant/cpriego-valet-linux"
+      }
+    ]
+  }' >> ~/.config/composer/composer.json
+fi
+
+# Require Valet
+composer global require "cpriego/valet-linux @dev" --no-interaction --no-ansi
+
+# Add Composer bin to PATH
+echo "PATH=\"\$HOME/.config/composer/vendor/bin:\$PATH\"" >> ~/.profile
+source ~/.profile

--- a/tests/Acceptance/Vagrant/ubuntu1604/Vagrantfile
+++ b/tests/Acceptance/Vagrant/ubuntu1604/Vagrantfile
@@ -1,0 +1,13 @@
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/xenial64"
+
+  config.vm.synced_folder "../../../../", "/home/ubuntu/cpriego-valet-linux"
+
+  config.vm.provision "shell" do |s|
+    s.path = "provision.sh"
+    s.privileged = false
+    s.env = {
+      VALET_ENVIRONMENT: ENV['VALET_ENVIRONMENT'] || "testing"
+    }
+  end
+end

--- a/tests/Acceptance/Vagrant/ubuntu1604/provision.sh
+++ b/tests/Acceptance/Vagrant/ubuntu1604/provision.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+set -e
+
+sudo apt-get update
+
+# Install OS Requirements
+sudo apt-get install -y network-manager libnss3-tools jq xsel
+
+# Install Nginx & PHP
+sudo apt-get install -y nginx curl zip unzip git \
+              php-fpm php-cli php-mcrypt php-mbstring php-xml php-curl
+
+# Install Composer
+php -r "readfile('http://getcomposer.org/installer');" | sudo php -- --install-dir=/usr/bin/ --filename=composer
+
+# Remove .composer directory created during installation
+sudo rm -rf ~/.composer
+
+# Configure Composer
+mkdir -p ~/.config/composer
+if [ "$VALET_ENVIRONMENT" == "testing" ]
+then
+  # If we are testing, we mirror the repository
+  # so the shared folder stays untouched
+  echo '{
+    "minimum-stability": "dev",
+    "repositories": [
+      {
+        "type": "path",
+        "url": "/home/ubuntu/cpriego-valet-linux",
+        "options": {
+          "symlink": false
+        }
+      }
+    ]
+  }' >> ~/.config/composer/composer.json
+else
+  # If we are developing, we sync the repository with the shared folder
+  echo '{
+    "minimum-stability": "dev",
+    "repositories": [
+      {
+        "type": "path",
+        "url": "/home/ubuntu/cpriego-valet-linux"
+      }
+    ]
+  }' >> ~/.config/composer/composer.json
+fi
+
+# Require Valet
+composer global require "cpriego/valet-linux @dev" --no-interaction --no-ansi
+
+# Add Composer bin to PATH
+echo "PATH=\"\$HOME/.config/composer/vendor/bin:\$PATH\"" >> ~/.profile
+source ~/.profile

--- a/tests/Acceptance/Vagrant/ubuntu1704/Vagrantfile
+++ b/tests/Acceptance/Vagrant/ubuntu1704/Vagrantfile
@@ -1,0 +1,13 @@
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/zesty64"
+
+  config.vm.synced_folder "../../../../", "/home/ubuntu/cpriego-valet-linux"
+
+  config.vm.provision "shell" do |s|
+    s.path = "provision.sh"
+    s.privileged = false
+    s.env = {
+      VALET_ENVIRONMENT: ENV['VALET_ENVIRONMENT'] || "testing"
+    }
+  end
+end

--- a/tests/Acceptance/Vagrant/ubuntu1704/provision.sh
+++ b/tests/Acceptance/Vagrant/ubuntu1704/provision.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+set -e
+
+sudo apt-get update
+
+# Install OS Requirements
+sudo apt-get install -y network-manager libnss3-tools jq xsel
+
+# Install Nginx & PHP
+sudo apt-get install -y nginx curl zip unzip git \
+              php-fpm php-cli php-mcrypt php-mbstring php-xml php-curl
+
+# Install Composer
+php -r "readfile('http://getcomposer.org/installer');" | sudo php -- --install-dir=/usr/bin/ --filename=composer
+
+# Remove .composer directory created during installation
+sudo rm -rf ~/.composer
+
+# Configure Composer
+mkdir -p ~/.config/composer
+if [ "$VALET_ENVIRONMENT" == "testing" ]
+then
+  # If we are testing, we mirror the repository
+  # so the shared folder stays untouched
+  echo '{
+    "minimum-stability": "dev",
+    "repositories": [
+      {
+        "type": "path",
+        "url": "/home/ubuntu/cpriego-valet-linux",
+        "options": {
+          "symlink": false
+        }
+      }
+    ]
+  }' >> ~/.config/composer/composer.json
+else
+  # If we are developing, we sync the repository with the shared folder
+  echo '{
+    "minimum-stability": "dev",
+    "repositories": [
+      {
+        "type": "path",
+        "url": "/home/ubuntu/cpriego-valet-linux"
+      }
+    ]
+  }' >> ~/.config/composer/composer.json
+fi
+
+# Require Valet
+composer global require "cpriego/valet-linux @dev" --no-interaction --no-ansi
+
+# Add Composer bin to PATH
+echo "PATH=\"\$HOME/.config/composer/vendor/bin:\$PATH\"" >> ~/.profile
+source ~/.profile

--- a/tests/Acceptance/docker.sh
+++ b/tests/Acceptance/docker.sh
@@ -16,4 +16,4 @@ cd $REPOSITORY
 ./valet install
 
 # Run Functional tests
-vendor/bin/phpunit --group functional
+vendor/bin/phpunit --group functional --exclude-group none

--- a/tests/Acceptance/vagrant.sh
+++ b/tests/Acceptance/vagrant.sh
@@ -16,4 +16,4 @@ cd ~/cpriego-valet-linux
 valet install
 
 # Run Functional tests
-./vendor/bin/phpunit --group acceptance --exclude-group none
+./vendor/phpunit/phpunit/phpunit --group acceptance --exclude-group none

--- a/tests/Acceptance/vagrant.sh
+++ b/tests/Acceptance/vagrant.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Terminate as soon as one command fails (e)
+set -e
+
+# Source .profile for extra path etc
+if [ -f ~/.profile ]
+then
+    source ~/.profile
+fi
+
+# Go into repository workspace
+cd ~/cpriego-valet-linux
+
+# Install valet
+valet install
+
+# Run Functional tests
+./vendor/bin/phpunit --group acceptance --exclude-group none

--- a/tests/Functional/FunctionalTestCase.php
+++ b/tests/Functional/FunctionalTestCase.php
@@ -18,9 +18,21 @@ class FunctionalTestCase extends TestCase
      */
     protected function valetCommand($command, $workingDir = null)
     {
-        $valet = (isset($_SERVER['REPOSITORY']) ? $_SERVER['REPOSITORY'] . '/' : '') . 'valet';
+        return $this->exec($this->valet() . ' ' . $command, $workingDir);
+    }
 
-        return $this->exec($valet . ' ' . $command, $workingDir);
+    /**
+     * Get valet prefix for commands.
+     *
+     * @return string
+     */
+    protected function valet()
+    {
+        if (isset($_SERVER['REPOSITORY'])) {
+            return $_SERVER['REPOSITORY'] . '/valet';
+        }
+
+        return 'valet';
     }
 
     /**
@@ -49,5 +61,26 @@ class FunctionalTestCase extends TestCase
         }
 
         return $processOutput;
+    }
+
+    /**
+     * Run a command in the background.
+     *
+     * @param string $command
+     * @param null|string $workingDir
+     * @return Process
+     */
+    protected function background($command, $workingDir = null)
+    {
+        $process = new Process($command);
+
+        $process
+            ->setWorkingDirectory(
+                is_null($workingDir) ? realpath(__DIR__ . '/../..') : $workingDir
+            )
+            ->setTimeout(null)
+            ->start();
+
+        return $process;
     }
 }

--- a/tests/Functional/FunctionalTestCase.php
+++ b/tests/Functional/FunctionalTestCase.php
@@ -18,7 +18,9 @@ class FunctionalTestCase extends TestCase
      */
     protected function valetCommand($command, $workingDir = null)
     {
-        return $this->exec($_SERVER['REPOSITORY'] . '/valet ' . $command, $workingDir);
+        $valet = (isset($_SERVER['REPOSITORY']) ? $_SERVER['REPOSITORY'] . '/' : '') . 'valet';
+
+        return $this->exec($valet . ' ' . $command, $workingDir);
     }
 
     /**

--- a/tests/Functional/InstallTest.php
+++ b/tests/Functional/InstallTest.php
@@ -15,4 +15,11 @@ class InstallTest extends FunctionalTestCase
         $this->assertEquals(404, $response->code);
         $this->assertContains('Valet - Not Found', $response->body);
     }
+
+    public function test_dns_record_is_correct()
+    {
+        $record = dns_get_record('test.dev', DNS_A)[0];
+
+        $this->assertEquals('127.0.0.1', $record['ip']);
+    }
 }

--- a/tests/Functional/InstallTest.php
+++ b/tests/Functional/InstallTest.php
@@ -4,6 +4,7 @@ use Valet\Tests\Functional\FunctionalTestCase;
 
 /**
  * @group functional
+ * @group acceptance
  */
 class InstallTest extends FunctionalTestCase
 {

--- a/tests/Functional/LinkTest.php
+++ b/tests/Functional/LinkTest.php
@@ -4,6 +4,7 @@ use Valet\Tests\Functional\FunctionalTestCase;
 
 /**
  * @group functional
+ * @group acceptance
  */
 class LinkTest extends FunctionalTestCase
 {

--- a/tests/Functional/ParkTest.php
+++ b/tests/Functional/ParkTest.php
@@ -7,6 +7,7 @@ use Configuration;
 
 /**
  * @group functional
+ * @group acceptance
  */
 class ParkTest extends FunctionalTestCase
 {

--- a/tests/Functional/SecureTest.php
+++ b/tests/Functional/SecureTest.php
@@ -7,6 +7,7 @@ use Httpful\Exception\ConnectionErrorException;
 
 /**
  * @group functional
+ * @group acceptance
  */
 class SecureTest extends FunctionalTestCase
 {

--- a/tests/Functional/ShareTest.php
+++ b/tests/Functional/ShareTest.php
@@ -1,0 +1,65 @@
+<?php
+
+use Valet\Tests\Functional\FunctionalTestCase;
+
+/**
+ * @group functional
+ * @group acceptance
+ */
+class ShareTest extends FunctionalTestCase
+{
+    protected function setUp()
+    {
+        // Create filesystem structure
+        mkdir($_SERVER['HOME'] . '/valet-site');
+        file_put_contents($_SERVER['HOME'] . '/valet-site/index.html', 'Valet site');
+        $this->valetCommand('link valet', $_SERVER['HOME'] . '/valet-site');
+    }
+
+    protected function tearDown()
+    {
+        $this->valetCommand('unsecure', $_SERVER['HOME'] . '/valet-site');
+        Configuration::prune();
+        Filesystem::remove($_SERVER['HOME'] . '/valet-site');
+        Filesystem::removeBrokenLinksAt(VALET_HOME_PATH . '/Sites');
+    }
+
+    public function test_we_can_share_an_http_site()
+    {
+        // Start ngrok tunnel
+        $ngrok = $this->background($this->valet().' share', $_SERVER['HOME'] . '/valet-site');
+
+        // Assert tunnel URL is reachable
+        $tunnel = Ngrok::currentTunnelUrl();
+        $this->assertContains('ngrok.io', $tunnel);
+
+        $response = \Httpful\Request::get($tunnel)->send();
+        $this->assertEquals(200, $response->code);
+        $this->assertContains('Valet site', $response->body);
+
+        $ngrok->stop();
+    }
+
+    public function test_we_can_share_an_https_site()
+    {
+        // Secure site
+        $this->valetCommand('secure', $_SERVER['HOME'] . '/valet-site');
+
+        // Start ngrok tunnel
+        $ngrok = $this->background($this->valet().' share', $_SERVER['HOME'] . '/valet-site');
+
+        // Assert tunnel URL is reachable
+        $tunnel = Ngrok::currentTunnelUrl();
+
+        // TODO: Refactor Ngrok class so we can retrieve https tunnel too
+        $tunnel = str_replace('http://', 'https://', $tunnel);
+
+        $this->assertContains('ngrok.io', $tunnel);
+
+        $response = \Httpful\Request::get($tunnel)->send();
+        $this->assertEquals(200, $response->code);
+        $this->assertContains('Valet site', $response->body);
+
+        $ngrok->stop();
+    }
+}


### PR DESCRIPTION
I was trying to work on some features and realized this workflow is quite annoying. Every time I have to switch folder to spin up a virtual machine, configure it, test features, destroy it because my computer suffers etc. Docker didn't worked as well as I expected, so I decided to move one step up and use vagrant to "quickly" spin up some environments and run tests on them.

I know vagrant uses server boxes while Valet is intended for client usage, but it should be close enough to our needs. I expect network components to be the same on desktop and on server, minus the fancy GUIs.

There's one test failing, `ShareTest::test_we_can_share_an_https_site`, this is indeed a bug creating an infinite redirect when using Ngrok secure tunnels.

All commands are condensed into `./develop`, which has it's own help: 
```
Usage: ./develop [action] [arguments]

Available actions:
	up {OS_NAME}
		Spin up a development environment using vagrant and SSH into it.
		Available OSes: ubuntu1704 centos7 fedora25 ubuntu1404 fedora26 ubuntu1604 
	ssh {OS_NAME}
		SSH into the given development environment.
	down {OS_NAME}
		Switch off given development environment. This does NOT destroy the box.
	destroy {OS_NAME}
		Destroy given development environment.
	destroy-all
		Destroy all development environments.
	test {OS_NAME}
		Run Acceptance tests against a given OS.
	test-all
		Run Acceptance tests against ALL OSes.
	test-all-parallel
		Run Acceptance tests against ALL OSes in parellel. Requires gnome-terminal.
```

## Example
Spin up Ubuntu 16.04 environment: 
```
./develop up ubuntu1604
```
SSH into it:
```
./develop ssh ubuntu1604
```
Run Functional tests:
```
./develop test ubuntu1604
```
Destroy it at the end:
```
./develop destroy ubuntu1604
```