### PR TITLE
Added support for wildcard-ssl for domains

### DIFF
--- a/cli/stubs/openssl.conf
+++ b/cli/stubs/openssl.conf
@@ -19,3 +19,4 @@ subjectAltName = @alt_names
 
 [alt_names]
 DNS.1 = VALET_DOMAIN
+DNS.2 = *.VALET_DOMAIN


### PR DESCRIPTION
This pull-request will add support for wildcard-ssl for domains, currently;
```
project.dev = works with ssl
foobar.project.dev = didn't works with ssl
```
to
```
project.dev = works with ssl
foobar.project.dev = works with ssl
foo.project.dev = works with ssl

etc
```