### PR TITLE
HTTPS port

### DIFF
--- a/cli/Valet/Configuration.php
+++ b/cli/Valet/Configuration.php
@@ -198,6 +198,20 @@ class Configuration
     }
 
     /**
+     * Get a configuration value.
+     *
+     * @param string $key
+     * @param mixed $default
+     * @return mixed
+     */
+    public function get($key, $default = null)
+    {
+        $config = $this->read();
+
+        return array_key_exists($key, $config) ? $config[$key] : $default;
+    }
+
+    /**
      * Update a specific key in the configuration file.
      *
      * @param  string  $key

--- a/cli/Valet/Nginx.php
+++ b/cli/Valet/Nginx.php
@@ -80,7 +80,12 @@ class Nginx
 
         $this->files->putAsUser(
             $nginx,
-            str_replace(['VALET_USER', 'VALET_GROUP', 'VALET_HOME_PATH', 'VALET_PID'], [user(), group(), VALET_HOME_PATH, $pid_string], $contents)
+            str_array_replace([
+                'VALET_USER' => user(),
+                'VALET_GROUP' => group(),
+                'VALET_HOME_PATH' => VALET_HOME_PATH,
+                'VALET_PID' => $pid_string,
+            ], $contents)
         );
     }
 

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -75,7 +75,11 @@ class PhpFpm
 
         $this->files->putAsUser(
             $this->fpmConfigPath().'/valet.conf',
-            str_replace(['VALET_USER', 'VALET_GROUP','VALET_HOME_PATH'], [user(), group(), VALET_HOME_PATH], $contents)
+            str_array_replace([
+                'VALET_USER' => user(),
+                'VALET_GROUP' => group(),
+                'VALET_HOME_PATH' => VALET_HOME_PATH,
+            ], $contents)
         );
     }
 

--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -2,8 +2,6 @@
 
 namespace Valet;
 
-use DomainException;
-
 class Site
 {
     public $config;
@@ -321,9 +319,17 @@ class Site
     {
         $path = $this->certificatesPath();
 
-        return str_replace(
-            ['VALET_HOME_PATH', 'VALET_SERVER_PATH', 'VALET_SITE', 'VALET_CERT', 'VALET_KEY', 'VALET_HTTP_PORT', 'VALET_HTTPS_PORT', 'VALET_REDIRECT_PORT'],
-            [VALET_HOME_PATH, VALET_SERVER_PATH, $url, $path . '/' . $url . '.crt', $path . '/' . $url . '.key', $this->config->get('port', 80), $this->config->get('https_port', 443), $this->httpsSuffix()],
+        return str_array_replace(
+            [
+                'VALET_HOME_PATH' => VALET_HOME_PATH,
+                'VALET_SERVER_PATH' => VALET_SERVER_PATH,
+                'VALET_SITE' => $url,
+                'VALET_CERT' => $path . '/' . $url . '.crt',
+                'VALET_KEY' => $path . '/' . $url . '.key',
+                'VALET_HTTP_PORT' => $this->config->get('port', 80),
+                'VALET_HTTPS_PORT' => $this->config->get('https_port', 443),
+                'VALET_REDIRECT_PORT' => $this->httpsSuffix(),
+            ],
             $this->files->get(__DIR__ . '/../stubs/secure.valet.conf')
         );
     }

--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -89,7 +89,7 @@ class Site
         return collect($this->files->scanDir($path))->filter(function ($value, $key) {
             return ends_with($value, '.crt');
         })->map(function ($cert) {
-            return substr($cert, 0, -8);
+            return substr($cert, 0, -9);
         })->flip();
     }
 

--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -104,7 +104,8 @@ class Site
     {
         $config = $this->config->read();
 
-        list($httpPort, $httpsPort) = $this->portSuffixes();
+        $httpPort = $this->httpSuffix();
+        $httpsPort = $this->httpsSuffix();
 
         return collect($this->files->scanDir($path))->mapWithKeys(function ($site) use ($path) {
             return [$site => $this->files->readLink($path . '/' . $site)];
@@ -118,19 +119,27 @@ class Site
     }
 
     /**
-     * Return port suffixes
+     * Return http port suffix
      *
-     * @return array
+     * @return string
      */
-    public function portSuffixes()
+    public function httpSuffix()
     {
-        $httpPort = $this->config->get('port', 80);
-        $httpPort = ($httpPort == 80) ? '' : ':' . $httpPort;
+        $port = $this->config->get('port', 80);
 
-        $httpsPort = $this->config->get('https_port', 443);
-        $httpsPort = ($httpsPort == 443) ? '' : ':' . $httpsPort;
+        return ($port == 80) ? '' : ':' . $port;
+    }
 
-        return [$httpPort, $httpsPort];
+    /**
+     * Return https port suffix
+     *
+     * @return string
+     */
+    public function httpsSuffix()
+    {
+        $port = $this->config->get('https_port', 443);
+
+        return ($port == 443) ? '' : ':' . $port;
     }
 
     /**
@@ -313,8 +322,8 @@ class Site
         $path = $this->certificatesPath();
 
         return str_replace(
-            ['VALET_HOME_PATH', 'VALET_SERVER_PATH', 'VALET_SITE', 'VALET_CERT', 'VALET_KEY', 'VALET_HTTP_PORT', 'VALET_HTTPS_PORT'],
-            [VALET_HOME_PATH, VALET_SERVER_PATH, $url, $path . '/' . $url . '.crt', $path . '/' . $url . '.key', $this->config->get('port', 80), $this->config->get('https_port', 443)],
+            ['VALET_HOME_PATH', 'VALET_SERVER_PATH', 'VALET_SITE', 'VALET_CERT', 'VALET_KEY', 'VALET_HTTP_PORT', 'VALET_HTTPS_PORT', 'VALET_REDIRECT_PORT'],
+            [VALET_HOME_PATH, VALET_SERVER_PATH, $url, $path . '/' . $url . '.crt', $path . '/' . $url . '.key', $this->config->get('port', 80), $this->config->get('https_port', 443), $this->httpsSuffix()],
             $this->files->get(__DIR__ . '/../stubs/secure.valet.conf')
         );
     }

--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -104,14 +104,33 @@ class Site
     {
         $config = $this->config->read();
 
+        list($httpPort, $httpsPort) = $this->portSuffixes();
+
         return collect($this->files->scanDir($path))->mapWithKeys(function ($site) use ($path) {
             return [$site => $this->files->readLink($path . '/' . $site)];
-        })->map(function ($path, $site) use ($certs, $config) {
+        })->map(function ($path, $site) use ($certs, $config, $httpPort, $httpsPort) {
             $secured = $certs->has($site);
-            $url = ($secured ? 'https' : 'http') . '://' . $site . '.' . $config['domain'];
+
+            $url = ($secured ? 'https' : 'http') . '://' . $site . '.' . $config['domain'] . ($secured ? $httpsPort : $httpPort);
 
             return [$site, $secured ? ' X' : '', $url, $path];
         });
+    }
+
+    /**
+     * Return port suffixes
+     *
+     * @return array
+     */
+    public function portSuffixes()
+    {
+        $httpPort = $this->config->get('port', 80);
+        $httpPort = ($httpPort == 80) ? '' : ':' . $httpPort;
+
+        $httpsPort = $this->config->get('https_port', 443);
+        $httpsPort = ($httpsPort == 443) ? '' : ':' . $httpsPort;
+
+        return [$httpPort, $httpsPort];
     }
 
     /**

--- a/cli/includes/helpers.php
+++ b/cli/includes/helpers.php
@@ -189,3 +189,15 @@ function group()
 
     return exec('id -gn '.$_SERVER['SUDO_USER']);
 }
+
+/**
+ * Search and replace using associative array
+ *
+ * @param array $searchAndReplace
+ * @param string $subject
+ * @return string
+ */
+function str_array_replace($searchAndReplace, $subject)
+{
+    return str_replace(array_keys($searchAndReplace), array_values($searchAndReplace), $subject);
+}

--- a/cli/stubs/secure.valet.conf
+++ b/cli/stubs/secure.valet.conf
@@ -1,7 +1,7 @@
 server {
     listen VALET_HTTP_PORT;
     server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
-    return 301 https://$host:VALET_HTTPS_PORT$request_uri;
+    return 301 https://$hostVALET_REDIRECT_PORT$request_uri;
 }
 
 server {

--- a/cli/stubs/secure.valet.conf
+++ b/cli/stubs/secure.valet.conf
@@ -1,11 +1,11 @@
 server {
-    listen 80;
+    listen VALET_HTTP_PORT;
     server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
-    return 301 https://$host$request_uri;
+    return 301 https://$host:VALET_HTTPS_PORT$request_uri;
 }
 
 server {
-    listen 443 ssl http2;
+    listen VALET_HTTPS_PORT ssl http2;
     server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
     root /;
     charset utf-8;

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -90,11 +90,12 @@ if (is_dir(VALET_HOME_PATH)) {
 
         if ($https) {
             Configuration::updateKey('https_port', $port);
-            Site::regenerateSecuredSitesConfig();
         }else{
             Nginx::updatePort($port);
             Configuration::updateKey('port', $port);
         }
+
+        Site::regenerateSecuredSitesConfig();
 
         Nginx::restart();
         PhpFpm::restart();

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -104,6 +104,19 @@ if (is_dir(VALET_HOME_PATH)) {
     })->descriptions('Get or set the port number used for Valet sites');
 
     /**
+     * Determine if the site is secured or not
+     */
+    $app->command('secured [site]', function ($site) {
+        if (Site::secured()->contains($site)) {
+            info("{$site} is secured.");
+            return 1;
+        }
+
+        info("{$site} is not secured.");
+        return 0;
+    })->descriptions('Determine if the site is secured or not');
+
+    /**
      * Add the current working directory to the paths configuration.
      */
     $app->command('park [path]', function ($path = null) {

--- a/tests/Functional/ShareTest.php
+++ b/tests/Functional/ShareTest.php
@@ -39,27 +39,4 @@ class ShareTest extends FunctionalTestCase
 
         $ngrok->stop();
     }
-
-    public function test_we_can_share_an_https_site()
-    {
-        // Secure site
-        $this->valetCommand('secure', $_SERVER['HOME'] . '/valet-site');
-
-        // Start ngrok tunnel
-        $ngrok = $this->background($this->valet().' share', $_SERVER['HOME'] . '/valet-site');
-
-        // Assert tunnel URL is reachable
-        $tunnel = Ngrok::currentTunnelUrl();
-
-        // TODO: Refactor Ngrok class so we can retrieve https tunnel too
-        $tunnel = str_replace('http://', 'https://', $tunnel);
-
-        $this->assertContains('ngrok.io', $tunnel);
-
-        $response = \Httpful\Request::get($tunnel)->send();
-        $this->assertEquals(200, $response->code);
-        $this->assertContains('Valet site', $response->body);
-
-        $ngrok->stop();
-    }
 }

--- a/valet
+++ b/valet
@@ -89,6 +89,11 @@ then
         fi
     done
 
+    php "$DIR/cli/valet.php" secured "$HOST.$DOMAIN" &> /dev/null || (
+        printf "\033[1;31mSecured sites can not be shared.\033[0m\n"
+        exit 1
+    )
+
     # Fetch Ngrok URL In Background...
     bash "$DIR/cli/scripts/fetch-share-url.sh" &
     sudo -u $USER "$DIR/bin/ngrok" http "$HOST.$DOMAIN:$PORT" -host-header=rewrite ${*:2}


### PR DESCRIPTION
Add a command to configure a custom HTTPS port:

```
valet port --https 44343
```

This should be backwards compatible since it default to 443 if no port is specified.

Also fixed:
- `valet links` not considering custom port
- `valet share` on secured site (See #107 )