### PR TITLE
Support mix-case domains

### DIFF
--- a/server.php
+++ b/server.php
@@ -121,7 +121,7 @@ $uri = urldecode(
 
 $siteName = basename(
     // Filter host to support xip.io feature
-    valet_support_xip_io(explode(':',$_SERVER['HTTP_HOST'])[0]),
+    valet_support_xip_io(explode(':',strtolower($_SERVER['HTTP_HOST']))[0]),
     '.'.$valetConfig['domain']
 );
 


### PR DESCRIPTION
Valet doesn't support mix-case domains if you request a domain with uppercase characters.
`curl http://someDomain.test` will result in a `404 - Valet Not Found` even if `someDomain` folder exists. 
See https://github.com/cpriego/valet-linux/issues/128#issuecomment-358134245 for detailed explanation.

The solution is to lowercase the host parameter before matching it with folder slug (which is already lowercased). 