### PR TITLE
Fixed empty $SERVER['document_root'] environment variable in Magento …

### DIFF
--- a/cli/drivers/Magento2ValetDriver.php
+++ b/cli/drivers/Magento2ValetDriver.php
@@ -144,8 +144,10 @@ class Magento2ValetDriver extends ValetDriver
         $this->checkMageMode($sitePath);
 
         if ('developer' === $this->mageMode) {
+            $_SERVER['DOCUMENT_ROOT'] = $sitePath;
             return $sitePath . '/index.php';
         }
+        $_SERVER['DOCUMENT_ROOT'] = $sitePath . '/pub';
         return $sitePath . '/pub/index.php';
     }
 }


### PR DESCRIPTION
…2 Driver

Changed the driver method according to the original Valet Magento 2 driver
https://github.com/laravel/valet/blob/master/cli/drivers/Magento2ValetDriver.php