### PR TITLE
Enforcing php >= 7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: xenial
 language: php
 
 sudo: required
@@ -11,7 +11,8 @@ env:
 php:
   - 7.0
   - 7.1
-  - nightly
+  - 7.2
+  - 7.3
 
 before_install:
   - travis_retry composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ env:
     - APP_ENV=testing
 
 php:
-  - 5.6
   - 7.0
   - 7.1
   - nightly

--- a/cli/drivers/BasicValetDriver.php
+++ b/cli/drivers/BasicValetDriver.php
@@ -25,7 +25,11 @@ class BasicValetDriver extends ValetDriver
      */
     public function isStaticFile($sitePath, $siteName, $uri)
     {
-        if (file_exists($staticFilePath = $sitePath.'/public'.$uri)) {
+        if (file_exists($staticFilePath = $sitePath.'/public'.rtrim($uri, '/').'/index.html')) {
+            return $staticFilePath;
+        } elseif (file_exists($staticFilePath = $sitePath.'/public'.rtrim($uri, '/').'/index.php')) {
+            return $staticFilePath;
+        } elseif (file_exists($staticFilePath = $sitePath.'/public'.$uri)) {
             return $staticFilePath;
         } elseif ($this->isActualFile($staticFilePath = $sitePath.$uri)) {
             return $staticFilePath;
@@ -44,6 +48,10 @@ class BasicValetDriver extends ValetDriver
      */
     public function frontControllerPath($sitePath, $siteName, $uri)
     {
+        $_SERVER['PHP_SELF']    = $uri;
+        $_SERVER['SERVER_ADDR'] = '127.0.0.1';
+        $_SERVER['SERVER_NAME'] = $_SERVER['HTTP_HOST'];
+		
         $dynamicCandidates = [
             $this->asActualFile($sitePath, $uri),
             $this->asPhpIndexFileInDirectory($sitePath, $uri),

--- a/cli/drivers/BedrockValetDriver.php
+++ b/cli/drivers/BedrockValetDriver.php
@@ -48,6 +48,7 @@ class BedrockValetDriver extends BasicValetDriver
     public function frontControllerPath($sitePath, $siteName, $uri)
     {
         $_SERVER['PHP_SELF'] = $uri;
+        $_SERVER['SERVER_NAME'] = $_SERVER['HTTP_HOST'];
 
         if (strpos($uri, '/wp/') === 0) {
             return is_dir($sitePath.'/web'.$uri)

--- a/cli/drivers/ContaoValetDriver.php
+++ b/cli/drivers/ContaoValetDriver.php
@@ -46,6 +46,13 @@ class ContaoValetDriver extends ValetDriver
             return $sitePath.'/web/install.php';
         }
 
+        if (0 === strncmp($uri, '/app_dev.php', 12)) {
+            $_SERVER['SCRIPT_NAME'] = '/app_dev.php';
+            $_SERVER['SCRIPT_FILENAME'] = $sitePath.'/app_dev.php';
+
+            return $sitePath.'/web/app_dev.php';
+        }
+
         return $sitePath.'/web/app.php';
     }
 }

--- a/cli/drivers/CraftValetDriver.php
+++ b/cli/drivers/CraftValetDriver.php
@@ -23,6 +23,14 @@ class CraftValetDriver extends ValetDriver
      */
     public function frontControllerDirectory($sitePath)
     {
+        $dirs = ['web', 'public'];
+
+        foreach ($dirs as $dir) {
+            if (is_dir($sitePath.'/'.$dir)) {
+                return $dir;
+            }
+        }
+        // Give up, and just return the default
         return is_file($sitePath.'/craft') ? 'web' : 'public';
     }
 
@@ -183,8 +191,13 @@ class CraftValetDriver extends ValetDriver
         $parts = explode('/', $uri);
 
         if (count($parts) > 1 && in_array($parts[1], $locales)) {
-            $indexPath = $sitePath.'/public/'. $parts[1] .'/index.php';
-            $scriptName = '/' . $parts[1] . '/index.php';
+            $indexLocalizedPath = $sitePath.'/'.$frontControllerDirectory.'/'.$parts[1].'/index.php';
+
+            // Check if index.php exists in the localized folder, this is optional in Craft 3
+            if (file_exists($indexLocalizedPath)) {
+                $indexPath = $indexLocalizedPath;
+                $scriptName = '/' . $parts[1] . '/index.php';
+            }
         }
 
         $_SERVER['SCRIPT_FILENAME'] = $indexPath;

--- a/cli/drivers/DrupalValetDriver.php
+++ b/cli/drivers/DrupalValetDriver.php
@@ -12,6 +12,8 @@ class DrupalValetDriver extends ValetDriver
      */
     public function serves($sitePath, $siteName, $uri)
     {
+        $sitePath = $this->addSubdirectory($sitePath);
+
       /**
        * /misc/drupal.js = Drupal 7
        * /core/lib/Drupal.php = Drupal 8
@@ -32,6 +34,8 @@ class DrupalValetDriver extends ValetDriver
      */
     public function isStaticFile($sitePath, $siteName, $uri)
     {
+        $sitePath = $this->addSubdirectory($sitePath);
+
         if (file_exists($sitePath.$uri) &&
             ! is_dir($sitePath.$uri) &&
             pathinfo($sitePath.$uri)['extension'] != 'php') {
@@ -51,7 +55,9 @@ class DrupalValetDriver extends ValetDriver
      */
     public function frontControllerPath($sitePath, $siteName, $uri)
     {
-        if (!empty($uri) && $uri !== '/') {
+        $sitePath = $this->addSubdirectory($sitePath);
+
+        if (!isset($_GET['q']) && !empty($uri) && $uri !== '/') {
           $_GET['q'] = $uri;
         }
 
@@ -69,5 +75,37 @@ class DrupalValetDriver extends ValetDriver
         $_SERVER['SCRIPT_FILENAME'] = $sitePath.'/index.php';
         $_SERVER['SCRIPT_NAME'] = '/index.php';
         return $sitePath.'/index.php';
+    }
+
+    /**
+     * Add any matching subdirectory to the site path.
+     */
+    public function addSubdirectory($sitePath)
+    {
+        $paths = array_map(function ($subDir) use ($sitePath) {
+            return "$sitePath/$subDir";
+        }, $this->possibleSubdirectories());
+
+        $foundPaths = array_filter($paths, function ($path) {
+            return file_exists($path);
+        });
+
+        // If paths are found, return the first one.
+        if (!empty($foundPaths)) {
+            return array_shift($foundPaths);
+        }
+
+        // If there are no matches, return the original path.
+        return $sitePath;
+    }
+
+    /**
+     * Return an array of possible subdirectories.
+     *
+     * @return array
+     */
+    private function possibleSubdirectories()
+    {
+        return ['docroot', 'public', 'web'];
     }
 }

--- a/cli/drivers/KirbyValetDriver.php
+++ b/cli/drivers/KirbyValetDriver.php
@@ -45,7 +45,7 @@ class KirbyValetDriver extends ValetDriver
         // Needed to force Kirby to use *.test to generate its URLs...
         $_SERVER['SERVER_NAME'] = $_SERVER['HTTP_HOST'];
 
-        if (preg_match('/^\/panel/', $uri)) {
+        if (preg_match('/^\/panel/', $uri) && file_exists($sitePath . '/panel/index.php')) {
             $_SERVER['SCRIPT_NAME'] = '/panel/index.php';
 
             return $sitePath.'/panel/index.php';

--- a/cli/drivers/SculpinValetDriver.php
+++ b/cli/drivers/SculpinValetDriver.php
@@ -12,7 +12,36 @@ class SculpinValetDriver extends BasicValetDriver
      */
     public function serves($sitePath, $siteName, $uri)
     {
+        return $this->isModernSculpinProject($sitePath) ||
+            $this->isLegacySculpinProject($sitePath);
+    }
+
+    private function isModernSculpinProject($sitePath)
+    {
+        return is_dir($sitePath.'/source') &&
+            is_dir($sitePath.'/output_dev') &&
+            $this->composerRequiresSculpin($sitePath);
+    }
+
+    private function isLegacySculpinProject($sitePath)
+    {
         return is_dir($sitePath.'/.sculpin');
+    }
+
+    private function composerRequiresSculpin($sitePath)
+    {
+        if (! file_exists($sitePath.'/composer.json')) {
+            return false;
+        }
+
+        $composer_json_source = file_get_contents($sitePath.'/composer.json');
+        $composer_json = json_decode($composer_json_source, true);
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            return false;
+        }
+
+        return isset($composer_json['require']['sculpin/sculpin']);
     }
 
     /**

--- a/cli/drivers/StatamicValetDriver.php
+++ b/cli/drivers/StatamicValetDriver.php
@@ -48,30 +48,99 @@ class StatamicValetDriver extends ValetDriver
      */
     public function frontControllerPath($sitePath, $siteName, $uri)
     {
-        if (file_exists($staticPath = $sitePath.'/static'.$uri.'/index.html')) {
+        if ($_SERVER['REQUEST_METHOD'] === 'GET' && $this->isActualFile($staticPath = $this->getStaticPath($sitePath))) {
             return $staticPath;
-        }
-
-        $_SERVER['SCRIPT_NAME'] = '/index.php';
-
-        if (strpos($_SERVER['REQUEST_URI'], '/index.php') === 0) {
-            $_SERVER['REQUEST_URI'] = substr($_SERVER['REQUEST_URI'], 10);
-        }
-
-        if ($uri === '') {
-            $uri = '/';
         }
 
         if ($uri === '/installer.php') {
             return $sitePath.'/installer.php';
         }
 
-        if (file_exists($indexPath = $sitePath.'/index.php')) {
-            return $indexPath;
+        $scriptName = '/index.php';
+
+        if ($this->isActualFile($sitePath.'/index.php')) {
+            $indexPath = $sitePath.'/index.php';
         }
 
-        if (file_exists($indexPath = $sitePath.'/public/index.php')) {
-            return $indexPath;
+        if ($isAboveWebroot = $this->isActualFile($sitePath.'/public/index.php')) {
+            $indexPath = $sitePath.'/public/index.php';
         }
+
+        $sitePathPrefix = ($isAboveWebroot) ? $sitePath.'/public' : $sitePath;
+
+        if ($locale = $this->getUriLocale($uri)) {
+            if ($this->isActualFile($localeIndexPath = $sitePathPrefix . '/' . $locale . '/index.php')) {
+                // Force trailing slashes on locale roots.
+                if ($uri === '/' . $locale) {
+                    header('Location: ' . $uri . '/');
+                    die;
+                }
+
+                $indexPath = $localeIndexPath;
+                $scriptName = '/' . $locale . '/index.php';
+            }
+        }
+
+        $_SERVER['SCRIPT_NAME'] = $scriptName;
+        $_SERVER['SCRIPT_FILENAME'] = $sitePathPrefix . $scriptName;
+
+        return $indexPath;
+    }
+
+    /**
+     * Get the locale from this URI
+     *
+     * @param  string  $uri
+     * @return string|null
+     */
+    public function getUriLocale($uri)
+    {
+        $parts = explode('/', $uri);
+        $locale = $parts[1];
+
+        if (count($parts) < 2 || ! in_array($locale, $this->getLocales())) {
+            return;
+        }
+
+        return $locale;
+    }
+
+    /**
+     * Get the list of possible locales used in the first segment of a URI
+     *
+     * @return array
+     */
+    public function getLocales()
+    {
+        return [
+            'af', 'ax', 'al', 'dz', 'as', 'ad', 'ao', 'ai', 'aq', 'ag', 'ar', 'am', 'aw', 'au', 'at', 'az', 'bs', 'bh',
+            'bd', 'bb', 'by', 'be', 'bz', 'bj', 'bm', 'bt', 'bo', 'bq', 'ba', 'bw', 'bv', 'br', 'io', 'bn', 'bg', 'bf',
+            'bi', 'cv', 'kh', 'cm', 'ca', 'ky', 'cf', 'td', 'cl', 'cn', 'cx', 'cc', 'co', 'km', 'cg', 'cd', 'ck', 'cr',
+            'ci', 'hr', 'cu', 'cw', 'cy', 'cz', 'dk', 'dj', 'dm', 'do', 'ec', 'eg', 'sv', 'gq', 'er', 'ee', 'et', 'fk',
+            'fo', 'fj', 'fi', 'fr', 'gf', 'pf', 'tf', 'ga', 'gm', 'ge', 'de', 'gh', 'gi', 'gr', 'gl', 'gd', 'gp', 'gu',
+            'gt', 'gg', 'gn', 'gw', 'gy', 'ht', 'hm', 'va', 'hn', 'hk', 'hu', 'is', 'in', 'id', 'ir', 'iq', 'ie', 'im',
+            'il', 'it', 'jm', 'jp', 'je', 'jo', 'kz', 'ke', 'ki', 'kp', 'kr', 'kw', 'kg', 'la', 'lv', 'lb', 'ls', 'lr',
+            'ly', 'li', 'lt', 'lu', 'mo', 'mk', 'mg', 'mw', 'my', 'mv', 'ml', 'mt', 'mh', 'mq', 'mr', 'mu', 'yt', 'mx',
+            'fm', 'md', 'mc', 'mn', 'me', 'ms', 'ma', 'mz', 'mm', 'na', 'nr', 'np', 'nl', 'nc', 'nz', 'ni', 'ne', 'ng',
+            'nu', 'nf', 'mp', 'no', 'om', 'pk', 'pw', 'ps', 'pa', 'pg', 'py', 'pe', 'ph', 'pn', 'pl', 'pt', 'pr', 'qa',
+            're', 'ro', 'ru', 'rw', 'bl', 'sh', 'kn', 'lc', 'mf', 'pm', 'vc', 'ws', 'sm', 'st', 'sa', 'sn', 'rs', 'sc',
+            'sl', 'sg', 'sx', 'sk', 'si', 'sb', 'so', 'za', 'gs', 'ss', 'es', 'lk', 'sd', 'sr', 'sj', 'sz', 'se', 'ch',
+            'sy', 'tw', 'tj', 'tz', 'th', 'tl', 'tg', 'tk', 'to', 'tt', 'tn', 'tr', 'tm', 'tc', 'tv', 'ug', 'ua', 'ae',
+            'gb', 'us', 'um', 'uy', 'uz', 'vu', 've', 'vn', 'vg', 'vi', 'wf', 'eh', 'ye', 'zm', 'zw', 'en',
+        ];
+    }
+
+    /**
+     * Get the path to a statically cached page
+     *
+     * @param  string $sitePath
+     * @return string
+     */
+    protected function getStaticPath($sitePath)
+    {
+        $parts = parse_url($_SERVER['REQUEST_URI']);
+        $query = isset($parts['query']) ? $parts['query'] : '';
+
+        return $sitePath . '/static' . $parts['path'] . '_' . $query . '.html';
     }
 }

--- a/cli/drivers/SymfonyValetDriver.php
+++ b/cli/drivers/SymfonyValetDriver.php
@@ -13,7 +13,7 @@ class SymfonyValetDriver extends ValetDriver
     public function serves($sitePath, $siteName, $uri)
     {
         return (file_exists($sitePath.'/web/app_dev.php') || file_exists($sitePath.'/web/app.php')) &&
-               (file_exists($sitePath.'/app/AppKernel.php')) || (file_exists($sitePath.'/web/index.php')) &&
+               (file_exists($sitePath.'/app/AppKernel.php')) || (file_exists($sitePath.'/public/index.php')) &&
                (file_exists($sitePath.'/src/Kernel.php'))
             ;
     }
@@ -29,6 +29,8 @@ class SymfonyValetDriver extends ValetDriver
     public function isStaticFile($sitePath, $siteName, $uri)
     {
         if ($this->isActualFile($staticFilePath = $sitePath.'/web/'.$uri)) {
+            return $staticFilePath;
+        } elseif ($this->isActualFile($staticFilePath = $sitePath.'/public/'.$uri)) {
             return $staticFilePath;
         }
 
@@ -49,7 +51,7 @@ class SymfonyValetDriver extends ValetDriver
             return $frontControllerPath;
         } elseif (file_exists($frontControllerPath = $sitePath.'/web/app.php')) {
             return $frontControllerPath;
-        } elseif (file_exists($frontControllerPath = $sitePath.'/web/index.php')) {
+        } elseif (file_exists($frontControllerPath = $sitePath.'/public/index.php')) {
             return $frontControllerPath;
         }
     }

--- a/cli/drivers/ValetDriver.php
+++ b/cli/drivers/ValetDriver.php
@@ -178,4 +178,35 @@ abstract class ValetDriver
     {
         return ! is_dir($path) && file_exists($path);
     }
+
+    /**
+     * Load server environment variables if available.
+     * Processes any '*' entries first, and then adds site-specific entries
+     *
+     * @param  string  $sitePath
+     * @param  string  $siteName
+     * @return void
+     */
+    public function loadServerEnvironmentVariables($sitePath, $siteName)
+    {
+        $varFilePath = $sitePath . '/.valet-env.php';
+        if (! file_exists($varFilePath)) {
+            return;
+        }
+
+        $variables = include $varFilePath;
+
+        $variablesToSet = isset($variables['*']) ? $variables['*'] : [];
+
+        if (isset($variables[$siteName])) {
+            $variablesToSet = array_merge($variablesToSet, $variables[$siteName]);
+        }
+
+        foreach ($variablesToSet as $key => $value) {
+            if (! is_string($key)) continue;
+            $_SERVER[$key] = $value;
+            $_ENV[$key] = $value;
+            putenv($key . '=' . $value);
+        }
+    }
 }

--- a/cli/stubs/secure.valet.conf
+++ b/cli/stubs/secure.valet.conf
@@ -43,3 +43,39 @@ server {
         deny all;
     }
 }
+
+server {
+    listen 88;
+    server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
+    root /;
+    charset utf-8;
+    client_max_body_size 128M;
+
+    location /VALET_STATIC_PREFIX/ {
+        internal;
+        alias /;
+        try_files $uri $uri/;
+    }
+
+    location / {
+        rewrite ^ VALET_SERVER_PATH last;
+    }
+
+    access_log off;
+    error_log VALET_HOME_PATH/Log/nginx-error.log;
+
+    error_page 404 VALET_SERVER_PATH;
+
+    location ~ \.php$ {
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_pass unix:VALET_HOME_PATH/valet.sock;
+        fastcgi_index VALET_SERVER_PATH;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME VALET_SERVER_PATH;
+    }
+
+    location ~ /\.ht {
+        deny all;
+    }
+}
+

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -18,7 +18,7 @@ use Illuminate\Container\Container;
  */
 Container::setInstance(new Container);
 
-$version = 'v2.0.24';
+$version = 'v2.1.1';
 
 $app = new Application('Valet', $version);
 

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         }
     },
     "require": {
-        "php": ">=5.6",
+        "php": ">=7.0",
         "illuminate/container": "~5.3",
         "mnapoli/silly": "~1.1",
         "symfony/process": "~2.7|~3.0|~4.0",

--- a/server.php
+++ b/server.php
@@ -32,6 +32,10 @@ function valet_support_xip_io($domain)
         }
     }
 
+    if (strpos($domain, ':') !== false) {
+        $domain = explode(':',$domain)[0];
+    }
+
     return $domain;
 }
 

--- a/tests/Functional/InstallTest.php
+++ b/tests/Functional/InstallTest.php
@@ -18,7 +18,7 @@ class InstallTest extends FunctionalTestCase
 
     public function test_dns_record_is_correct()
     {
-        $record = dns_get_record('test.dev', DNS_A)[0];
+        $record = dns_get_record('test.test', DNS_A)[0];
 
         $this->assertEquals('127.0.0.1', $record['ip']);
     }

--- a/valet
+++ b/valet
@@ -87,10 +87,14 @@ then
         fi
     done
 
-    php "$DIR/cli/valet.php" secured "$HOST.$DOMAIN" &> /dev/null || (
-        printf "\033[1;31mSecured sites can not be shared.\033[0m\n"
-        exit 1
-    )
+    # Decide the correct PORT to use according if the site has a secure 
+    # config or not.
+    if grep --no-messages --quiet 443 ~/.valet/Nginx/$HOST*
+    then
+        PORT=88
+    else
+        PORT=80
+    fi
 
     # Fetch Ngrok URL In Background...
     bash "$DIR/cli/scripts/fetch-share-url.sh" &


### PR DESCRIPTION
This will stop anyone from trying to use Valet with PHP <= 5.6 as it will not work out of the box.  You can get around it with a bunch of work.

See 
* #205 
* https://github.com/laravel/valet/issues/742
* https://github.com/laravel/valet/issues/727
