### PR TITLE
Enforcing php >= 7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ env:
     - APP_ENV=testing
 
 php:
-  - 5.6
   - 7.0
   - 7.1
   - 7.2

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         }
     },
     "require": {
-        "php": ">=5.6",
+        "php": ">=7.0",
         "illuminate/container": "~5.3",
         "mnapoli/silly": "~1.1",
         "symfony/process": "~2.7|~3.0|~4.0",


### PR DESCRIPTION
This will stop anyone from trying to use Valet with PHP <= 5.6 as it will not work out of the box. You can get around it with a bunch of work.

See
- #205
- laravel#742
- laravel#727