### PR TITLE
Implemented php-fpm version switcher as `valet use`.

### DIFF
--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -65,6 +65,31 @@ class PhpFpm
     }
 
     /**
+     * Change the php-fpm version.
+     *
+     * @param string|float|int $version
+     *
+     * @return void
+     */
+    public function changeVersion($version = null) {
+        $this->stop();
+
+        if (!isset($version) || strtolower($version) === 'default') {
+            $this->version = $this->getVersion(true);
+        } else {
+            $this->version = $version;
+        }
+
+        $this->install();
+
+        if ($this->version !== $this->getVersion(true)) {
+            $this->files->putAsUser(VALET_HOME_PATH . '/use_php_version', $this->version);
+        } else {
+            $this->files->unlink(VALET_HOME_PATH . '/use_php_version');
+        }
+    }
+
+    /**
      * Update the PHP FPM configuration to use the current user.
      *
      * @return void
@@ -116,11 +141,19 @@ class PhpFpm
     /**
      * Get installed PHP version.
      *
+     * @param string $real force getting version from /usr/bin/php.
+     *
      * @return string
      */
-    public function getVersion()
+    public function getVersion($real = false)
     {
-        return explode('php', basename($this->files->readLink('/usr/bin/php')))[1];
+        if (!$real && $this->files->exists(VALET_HOME_PATH . '/use_php_version')) {
+            $version = $this->files->get(VALET_HOME_PATH . '/use_php_version');
+        } else {
+            $version = explode('php', basename($this->files->readLink('/usr/bin/php')))[1];
+        }
+
+        return $version;
     }
 
     /**

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -305,6 +305,16 @@ if (is_dir(VALET_HOME_PATH)) {
             passthru($script.' update');
         }
     })->descriptions('Update Valet Linux and clean up cruft');
+
+    /**
+     * Change the PHP version to the desired one.
+     */
+    $app->command('use [preferedversion]', function ($preferedversion = null) {
+        info('Changing php-fpm version...');
+        info('This does not affect php -v.');
+        PhpFpm::changeVersion($preferedversion);
+        info('php-fpm version successfully changed! 🎉');
+    })->descriptions('Set the PHP-fpm version to use, enter "default" or leave empty to use version: ' . PhpFpm::getVersion(true));
 }
 
 /**


### PR DESCRIPTION
Since i really enjoyed the `valet use` command from valetplus i added it in as a command.

This first stops the current php-fpm service, and (installs if needed) and runs the new php-fpm service.

after which it will add a file in the VALET_HOME_PATH with the current preferred fpm version which will convince valet that that is the current php version and will launch the new preferred version of php-fpm

Tested on Ubuntu 18.04 switching php 7.2 and php 7.3