### PR TITLE
fix: ngrok strange hostname error when sharing

### DIFF
--- a/valet
+++ b/valet
@@ -77,7 +77,7 @@ then
     check_dependencies
 
     HOST="${PWD##*/}"
-    DOMAIN=$(php "$DIR/cli/valet.php" domain)
+    DOMAIN=$(cat "$HOME/.valet/config.json" | jq -r ".domain")
     PORT=$(cat "$HOME/.valet/config.json" | jq -r ".port")
 
     for linkname in ~/.valet/Sites/*; do


### PR DESCRIPTION
This fixes the issue that occurs when `valet share` failed to start ngrok because of valet.php tool ANSI output for `domain` configuration value.

I fixed the issue on my Ubuntu computer by reading the domain TLD from `$HOME/.valet/config.json` instead just like when reading the PORT.

The error message that occurs before I fix it, notice the ANSI green domain name:

![Ngrok Error](https://i.ibb.co/HxYGZVm/Screenshot-from-2019-08-01-17-46-02.png)