### PR TITLE
Updates symfony/process dependency to 5.0 and fixes deprecated Process argument passed as string

### DIFF
--- a/cli/Valet/CommandLine.php
+++ b/cli/Valet/CommandLine.php
@@ -75,7 +75,15 @@ class CommandLine
         $onError = $onError ?: function () {
         };
 
-        $process = new Process($command);
+        // Symfony's 4.x Process component has deprecated passing a command string
+        // to the constructor, but older versions (which Valet's Composer
+        // constraints allow) don't have the fromShellCommandLine method.
+        // For more information, see: https://github.com/laravel/valet/pull/761
+        if (method_exists(Process::class, 'fromShellCommandline')) {
+            $process = Process::fromShellCommandline($command);
+        } else {
+            $process = new Process($command);
+        }
 
         $processOutput = '';
         $process->setTimeout(null)->run(function ($type, $line) use (&$processOutput) {

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "php": ">=7.0",
         "illuminate/container": "~5.3|^6.0",
         "mnapoli/silly": "~1.1",
-        "symfony/process": "~2.7|~3.0|~4.0",
+        "symfony/process": "~2.7|~3.0|~4.0|~5.0",
         "nategood/httpful": "~0.2",
         "tightenco/collect": "~5.3|^6.0",
         "ext-posix": "*",


### PR DESCRIPTION
Passing a command as string is deprecated since Symfony 4.2.

More information at [https://github.com/laravel/valet/pull/761](url)