### PR TITLE
Update conf for php74

### DIFF
--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -127,6 +127,22 @@ class PhpFpm
                 'VALET_HOME_PATH' => VALET_HOME_PATH,
             ], $contents)
         );
+
+        $this->systemdDropInOverride();
+    }
+
+    /**
+     * Install Drop-In systemd override for php-fpm service
+     *
+     * @return void
+     */
+    public function systemdDropInOverride()
+    {
+        $this->files->ensureDirExists('/etc/systemd/system/php-fpm.service.d');
+        $this->files->putAsUser(
+            '/etc/systemd/system/php-fpm.service.d/valet.conf',
+            $this->files->get(__DIR__ . '/../stubs/php-fpm.service.d/valet.conf')
+        );
     }
 
     /**

--- a/cli/stubs/fpm.conf
+++ b/cli/stubs/fpm.conf
@@ -2,10 +2,10 @@
 
 user = VALET_USER
 group = VALET_GROUP
-listen = VALET_HOME_PATH/valet.sock
+listen = /run/php-fpm/valet.sock
 
-listen.owner = VALET_USER
-listen.group = VALET_GROUP
+listen.acl_users = VALET_USER
+listen.acl_groups = VALET_GROUP
 
 pm = dynamic
 pm.start_servers = 2

--- a/cli/stubs/php-fpm.service.d/valet.conf
+++ b/cli/stubs/php-fpm.service.d/valet.conf
@@ -1,0 +1,2 @@
+[Service]
+ProtectHome=false

--- a/cli/stubs/valet.conf
+++ b/cli/stubs/valet.conf
@@ -24,7 +24,7 @@ server {
 
     location ~ \.php$ {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:VALET_HOME_PATH/valet.sock;
+        fastcgi_pass unix:/run/php-fpm/valet.sock;
         fastcgi_index VALET_SERVER_PATH;
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME VALET_SERVER_PATH;

--- a/tests/Integration/NginxTest.php
+++ b/tests/Integration/NginxTest.php
@@ -87,7 +87,7 @@ class NginxTest extends TestCase
             $this->assertTrue(strpos($contents, 'fastcgi_index ' . VALET_SERVER_PATH) !== false);
             $this->assertTrue(strpos($contents, 'fastcgi_param SCRIPT_FILENAME ' . VALET_SERVER_PATH) !== false);
             $this->assertTrue(strpos($contents, 'error_log ' . VALET_HOME_PATH . '/Log/nginx-error.log') !== false);
-            $this->assertTrue(strpos($contents, 'fastcgi_pass unix:' . VALET_HOME_PATH . '/valet.sock') !== false);
+            $this->assertTrue(strpos($contents, 'fastcgi_pass unix:/run/php-fpm/valet.sock') !== false);
         })->once();
 
         $files->shouldReceive('exists')->with('/etc/nginx/sites-enabled/default')->andReturn(true)->once();

--- a/tests/Integration/PhpFpmTest.php
+++ b/tests/Integration/PhpFpmTest.php
@@ -37,9 +37,9 @@ class PhpFpmTest extends TestCase
         $contents = file_get_contents(__DIR__ . '/output/valet.conf');
         $this->assertContains(sprintf("\nuser = %s", user()), $contents);
         $this->assertContains(sprintf("\ngroup = %s", group()), $contents);
-        $this->assertContains(sprintf("\nlisten.owner = %s", user()), $contents);
-        $this->assertContains(sprintf("\nlisten.group = %s", group()), $contents);
-        $this->assertContains("\nlisten = " . VALET_HOME_PATH . "/valet.sock", $contents);
+        $this->assertContains(sprintf("\nlisten.acl_users = %s", user()), $contents);
+        $this->assertContains(sprintf("\nlisten.acl_groups = %s", group()), $contents);
+        $this->assertContains("\nlisten = /run/php-fpm/valet.sock", $contents);
     }
 }
 
@@ -54,5 +54,10 @@ class StubForUpdatingFpmConfigFiles extends PhpFpm
     public function getVersion()
     {
         return '7.1';
+    }
+
+    public function systemdDropInOverride()
+    {
+        return;
     }
 }


### PR DESCRIPTION
1. Change socket location to `/run/php-fpm/valet.sock` instead of home folder
    This allows us to use default `CapabilityBoundingSet` instead of overriding it.

1. Add `ProtectHome=false` override for php-fpm service

This fixes #253 