### PR TITLE
add options to query all nameservers

### DIFF
--- a/cli/stubs/dnsmasq_options
+++ b/cli/stubs/dnsmasq_options
@@ -3,3 +3,5 @@ listen-address=127.0.0.1
 bind-interfaces
 cache-size=0
 proxy-dnssec
+all-servers
+strict-order


### PR DESCRIPTION
This solved a problem I had after installing valet where I couldn't resolve any names defined only inside a vpn. These two extra options will simply tell dnsmasq to look at all of the defined nameservers (/var/opt/valet-linux/dns-servers) and query each of them in order.