### PR TITLE
Add fastcgi_buffering to off

### DIFF
--- a/cli/stubs/secure.valet.conf
+++ b/cli/stubs/secure.valet.conf
@@ -32,6 +32,7 @@ server {
     error_page 404 VALET_SERVER_PATH;
 
     location ~ \.php$ {
+        fastcgi_buffering off;
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         fastcgi_pass unix:VALET_HOME_PATH/valet.sock;
         fastcgi_index VALET_SERVER_PATH;
@@ -67,6 +68,7 @@ server {
     error_page 404 VALET_SERVER_PATH;
 
     location ~ \.php$ {
+        fastcgi_buffering off;
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         fastcgi_pass unix:VALET_HOME_PATH/valet.sock;
         fastcgi_index VALET_SERVER_PATH;

--- a/cli/stubs/valet.conf
+++ b/cli/stubs/valet.conf
@@ -23,6 +23,7 @@ server {
     error_page 404 VALET_SERVER_PATH;
 
     location ~ \.php$ {
+        fastcgi_buffering off;
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         fastcgi_pass unix:VALET_HOME_PATH/valet.sock;
         fastcgi_index VALET_SERVER_PATH;


### PR DESCRIPTION
Some versions of WSL with PHP-FPM may sometimes completely hang and not load if proxy_buffering is not set to off.

It's also the standard in production to disable buffering for fastcgi.