### PR TITLE
Change CLI & FPM version when call 'valet use' command

### DIFF
--- a/cli/Valet/Nginx.php
+++ b/cli/Valet/Nginx.php
@@ -161,7 +161,11 @@ class Nginx
      */
     public function rewriteSecureNginxFiles()
     {
-        $domain = $this->configuration->read()['domain'];
+        $domain = $this->configuration->read()['domain'] ?? null;
+
+        if (! $domain) {
+            return;
+        }
 
         $this->site->resecureForNewDomain($domain, $domain);
     }

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -112,6 +112,20 @@ class PhpFpm
             info('Changing version failed');
             throw $exception;
         }
+
+        $this->updateCliVersion();
+    }
+
+    /**
+     * Update the PHP CLI version.
+     *
+     * @return void
+     */
+    protected function updateCliVersion()
+    {
+        $path = $this->cli->run("which php{$this->version}");
+
+        $this->cli->run("update-alternatives --set php $path");
     }
 
     /**

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -314,7 +314,6 @@ if (is_dir(VALET_HOME_PATH)) {
      */
     $app->command('use [preferedversion]', function ($preferedversion = null) {
         info('Changing php-fpm version...');
-        info('This does not affect php -v.');
         PhpFpm::changeVersion($preferedversion);
         info('php-fpm version successfully changed! 🎉');
     })->descriptions('Set the PHP-fpm version to use, enter "default" or leave empty to use version: ' . PhpFpm::getVersion(true));


### PR DESCRIPTION
For example if your php version is `7.3` and you want to switch to `7.4` with `valet use 7.4` the FPM version will be changed but the CLI version still `7.3` when call `php -v`, So this PR. fix that.
