### PR TITLE
Use -i for sudo for login shell

### DIFF
--- a/valet
+++ b/valet
@@ -55,7 +55,7 @@ then
 
     if [[ "$EUID" -ne 0 ]]
     then
-        sudo env HOME=$HOMEPATH $SOURCE "$@"
+        sudo -i env HOME=$HOMEPATH $SOURCE "$@"
         exit 0
     fi
 fi
@@ -64,7 +64,7 @@ if [[ -n $2 && "domain port" =~ $1 ]]
 then
     if [[ "$EUID" -ne 0 ]]
     then
-        sudo env HOME=$HOMEPATH $SOURCE "$@"
+        sudo -i env HOME=$HOMEPATH $SOURCE "$@"
         exit 0
     fi
 fi
@@ -98,7 +98,7 @@ then
 
     # Fetch Ngrok URL In Background...
     bash "$DIR/cli/scripts/fetch-share-url.sh" &
-    sudo -u $USER "$DIR/bin/ngrok" http "$HOST.$DOMAIN:$PORT" -host-header=rewrite ${*:2}
+    sudo -i -u $USER "$DIR/bin/ngrok" http "$HOST.$DOMAIN:$PORT" -host-header=rewrite ${*:2}
     exit
 
 # Finally, for every other command we will just proxy into the PHP tool


### PR DESCRIPTION
Fedora 33 locks php 7.4 and up, when using a remi repository you are forced to use a software collection for lower versions, but without using a login shell for sudo, the php command won't be available.

This just adds `-i` where valet tries to use sudo to enforce a login shell to use the version of php you have set for cli. Not sure if it would have any other repercussions or if there is a better way around it.

To reproduce this issue, look at the remi wizard https://rpms.remirepo.net/wizard/ and find a distro of linux that does not allow you to use a specific version of php without using a software collection (fedora 32/33 work for this) set up a machine using that distro and setup php with remi to use a version like 7.3 for fedora 32/33. Valet will fail any command it needs sudo for saying the php command is not found despite `php -v` working correctly.