### PR TITLE
Fix valet secure on latest browsers

### DIFF
--- a/cli/stubs/openssl.conf
+++ b/cli/stubs/openssl.conf
@@ -1,6 +1,8 @@
 [req]
+default_bits = 2048
 distinguished_name = req_distinguished_name
 req_extensions = v3_req
+prompt = no
 
 [req_distinguished_name]
 countryName = Country Name (2 letter code)
@@ -14,7 +16,9 @@ organizationalUnitName_default	= Domain Control Validated
 commonName = Internet Widgits Ltd
 commonName_max	= 64
 
-[ v3_req ]
+[v3_req]
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth
 subjectAltName = @alt_names
 
 [alt_names]


### PR DESCRIPTION
The latest browsers (Chrome, FF, Edge, etc) don't view the currently generated OpenSSL certs as valid, this change fixes this by specifying the key usage parameters, as well as defaulting the key size to 2048.