### PR TITLE
Change CLI & FPM version when call 'valet use' command

### DIFF
--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -112,6 +112,20 @@ class PhpFpm
             info('Changing version failed');
             throw $exception;
         }
+
+        $this->updateCliVersion();
+    }
+
+    /**
+     * Update the PHP CLI version.
+     *
+     * @return void
+     */
+    protected function updateCliVersion()
+    {
+        $path = $this->cli->run("which php{$this->version}");
+
+        $this->cli->run("update-alternatives --set php $path");
     }
 
     /**


### PR DESCRIPTION
[#305 ](https://github.com/cpriego/valet-linux/pull/305) Revert.
> For example if your php version is 7.3 and you want to switch to 7.4 with valet use 7.4 the FPM version will be changed but the CLI version still 7.3 when call php -v, So this PR. fix that.

