### PR TITLE
Add strict-order flag to dnsmasq options, providing better support for VPN DNS servers

### DIFF
--- a/cli/stubs/dnsmasq_options
+++ b/cli/stubs/dnsmasq_options
@@ -3,3 +3,4 @@ listen-address=127.0.0.1
 bind-interfaces
 cache-size=0
 proxy-dnssec
+strict-order


### PR DESCRIPTION
Currently there is an issue with NetworkManager created WireGuard instances, that it will correctly add/update the VPN's DNS servers to /etc/valet-linux/dns-servers, but dnsmasq ignores the new DNS server. Adding this flag forces it to use the first entry of the dns-servers file which would be the wanted DNS server.