### PR TITLE
Add compatibility to tests classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,9 +42,9 @@
     },
     "require": {
         "php": ">=7.0",
-        "illuminate/container": "~5.3|^6.0|^7.0|^8.0",
+        "illuminate/container": "~5.3|^6.0|^7.0|^8.0|^9.0",
         "mnapoli/silly": "~1.1",
-        "symfony/process": "~2.7|~3.0|~4.0|~5.0",
+        "symfony/process": "~2.7|~3.0|~4.0|~5.0|^6.0",
         "nategood/httpful": "~0.2",
         "tightenco/collect": "~5.3|^6.0|^7.0|^8.0",
         "ext-posix": "*",
@@ -52,7 +52,7 @@
         "outrightvision/api-model": "^1.0"
     },
     "require-dev": {
-        "mockery/mockery": "~0.9.4",
+        "mockery/mockery": "^1.2.3",
         "phpunit/phpunit": "~5.5|^9.0"
     },
     "scripts": {

--- a/tests/Functional/InstallTest.php
+++ b/tests/Functional/InstallTest.php
@@ -10,7 +10,6 @@ class InstallTest extends FunctionalTestCase
 {
     public function test_valet_is_running_after_install()
     {
-        $this->markTestSkipped();
         $response = \Httpful\Request::get('http://test.test')->send();
 
         $this->assertEquals(404, $response->code);

--- a/tests/Functional/InstallTest.php
+++ b/tests/Functional/InstallTest.php
@@ -10,6 +10,7 @@ class InstallTest extends FunctionalTestCase
 {
     public function test_valet_is_running_after_install()
     {
+        $this->markTestSkipped();
         $response = \Httpful\Request::get('http://test.test')->send();
 
         $this->assertEquals(404, $response->code);

--- a/tests/Functional/LinkTest.php
+++ b/tests/Functional/LinkTest.php
@@ -8,14 +8,14 @@ use Valet\Tests\Functional\FunctionalTestCase;
  */
 class LinkTest extends FunctionalTestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         // Create filesystem structure
         mkdir($_SERVER['HOME'] . '/linked-directory');
         file_put_contents($_SERVER['HOME'] . '/linked-directory/index.html', 'Valet linked site');
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         Filesystem::remove($_SERVER['HOME'] . '/linked-directory');
         Filesystem::removeBrokenLinksAt(VALET_HOME_PATH . '/Sites');

--- a/tests/Functional/ParkTest.php
+++ b/tests/Functional/ParkTest.php
@@ -11,7 +11,7 @@ use Filesystem;
  */
 class ParkTest extends FunctionalTestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         // Create filesystem structure
         mkdir($_SERVER['HOME'] . '/Code');
@@ -26,7 +26,7 @@ class ParkTest extends FunctionalTestCase
         file_put_contents($_SERVER['HOME'] . '/Code/with spaces/index.html', 'With Spaces');
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         Filesystem::remove($_SERVER['HOME'] . '/Code');
         Configuration::prune();

--- a/tests/Functional/SecureTest.php
+++ b/tests/Functional/SecureTest.php
@@ -11,7 +11,7 @@ use Httpful\Exception\ConnectionErrorException;
  */
 class SecureTest extends FunctionalTestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         // Create filesystem structure
         mkdir($_SERVER['HOME'] . '/valet-site');
@@ -19,7 +19,7 @@ class SecureTest extends FunctionalTestCase
         $this->valetCommand('link', $_SERVER['HOME'] . '/valet-site');
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->valetCommand('unlink', $_SERVER['HOME'] . '/valet-site');
         Filesystem::remove($_SERVER['HOME'] . '/valet-site');

--- a/tests/Functional/ShareTest.php
+++ b/tests/Functional/ShareTest.php
@@ -8,7 +8,7 @@ use Valet\Tests\Functional\FunctionalTestCase;
  */
 class ShareTest extends FunctionalTestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         // Create filesystem structure
         mkdir($_SERVER['HOME'] . '/valet-site');
@@ -16,7 +16,7 @@ class ShareTest extends FunctionalTestCase
         $this->valetCommand('link valet', $_SERVER['HOME'] . '/valet-site');
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->valetCommand('unsecure', $_SERVER['HOME'] . '/valet-site');
         Configuration::prune();

--- a/tests/Integration/AptTest.php
+++ b/tests/Integration/AptTest.php
@@ -7,7 +7,7 @@ use Valet\PackageManagers\Apt;
 
 class AptTest extends TestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         $_SERVER['SUDO_USER'] = user();
 
@@ -15,7 +15,7 @@ class AptTest extends TestCase
     }
 
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         Mockery::close();
     }
@@ -70,6 +70,8 @@ class AptTest extends TestCase
      */
     public function test_install_or_fail_throws_exception_on_failure()
     {
+        $this->expectException(DomainException::class);
+
         $cli = Mockery::mock(CommandLine::class);
         $cli->shouldReceive('run')->andReturnUsing(function ($command, $onError) {
             $onError(1, 'test error ouput');

--- a/tests/Integration/ConfigurationTest.php
+++ b/tests/Integration/ConfigurationTest.php
@@ -7,7 +7,7 @@ use Valet\Filesystem;
 
 class ConfigurationTest extends TestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         $_SERVER['SUDO_USER'] = user();
 
@@ -15,7 +15,7 @@ class ConfigurationTest extends TestCase
     }
 
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         Mockery::close();
     }

--- a/tests/Integration/DnsMasqTest.php
+++ b/tests/Integration/DnsMasqTest.php
@@ -10,14 +10,14 @@ use Valet\Filesystem;
 
 class DnsMasqTest extends TestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         $_SERVER['SUDO_USER'] = user();
         Container::setInstance(new Container);
     }
 
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         exec('rm -rf ' . __DIR__ . '/output');
         mkdir(__DIR__ . '/output');

--- a/tests/Integration/FilesystemTest.php
+++ b/tests/Integration/FilesystemTest.php
@@ -5,7 +5,7 @@ use Valet\Filesystem;
 
 class FilesystemTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         exec('rm -rf ' . __DIR__ . '/output');
         mkdir(__DIR__ . '/output');
@@ -21,6 +21,6 @@ class FilesystemTest extends TestCase
         $this->assertFileExists(__DIR__ . '/output/file.link');
         unlink(__DIR__ . '/output/file.out');
         $files->removeBrokenLinksAt(__DIR__ . '/output');
-        $this->assertFileNotExists(__DIR__ . '/output/file.link');
+        $this->assertFileDoesNotExist(__DIR__ . '/output/file.link');
     }
 }

--- a/tests/Integration/LinuxServiceTest.php
+++ b/tests/Integration/LinuxServiceTest.php
@@ -7,7 +7,7 @@ use Valet\ServiceManagers\LinuxService;
 
 class LinuxServiceTest extends TestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         $_SERVER['SUDO_USER'] = user();
 
@@ -15,7 +15,7 @@ class LinuxServiceTest extends TestCase
     }
 
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         Mockery::close();
     }

--- a/tests/Integration/NginxTest.php
+++ b/tests/Integration/NginxTest.php
@@ -12,7 +12,7 @@ use Valet\Site;
 
 class NginxTest extends TestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         $_SERVER['SUDO_USER'] = user();
 
@@ -20,7 +20,7 @@ class NginxTest extends TestCase
     }
 
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         Mockery::close();
     }
@@ -119,7 +119,7 @@ class NginxTest extends TestCase
         $files->shouldReceive('putAsUser')->with(VALET_HOME_PATH . '/Nginx/.keep', "\n")->once();
 
         swap(Filesystem::class, $files);
-        swap(Configuration::class, Mockery::spy(Configuration::class));
+        swap(Configuration::class, $config = Mockery::spy(Configuration::class, ['read' => ['domain' => 'test']]));
         swap(Site::class, Mockery::spy(Site::class));
         swap(PackageManager::class, Mockery::mock(PackageManager::class));
         swap(ServiceManager::class, Mockery::mock(ServiceManager::class));
@@ -137,7 +137,7 @@ class NginxTest extends TestCase
         $files->shouldReceive('putAsUser')->with(VALET_HOME_PATH . '/Nginx/.keep', "\n")->once();
 
         swap(Filesystem::class, $files);
-        swap(Configuration::class, Mockery::spy(Configuration::class));
+        swap(Configuration::class, $config = Mockery::spy(Configuration::class, ['read' => ['domain' => 'test']]));
         swap(Site::class, Mockery::spy(Site::class));
         swap(PackageManager::class, Mockery::mock(PackageManager::class));
         swap(ServiceManager::class, Mockery::mock(ServiceManager::class));

--- a/tests/Integration/PackageKitTest.php
+++ b/tests/Integration/PackageKitTest.php
@@ -7,7 +7,7 @@ use Valet\PackageManagers\PackageKit;
 
 class PackageKitTest extends TestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         $_SERVER['SUDO_USER'] = user();
 
@@ -15,7 +15,7 @@ class PackageKitTest extends TestCase
     }
 
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         Mockery::close();
     }
@@ -70,6 +70,8 @@ class PackageKitTest extends TestCase
      */
     public function test_install_or_fail_throws_exception_on_failure()
     {
+        $this->expectException(DomainException::class);
+
         $cli = Mockery::mock(CommandLine::class);
         $cli->shouldReceive('run')->andReturnUsing(function ($command, $onError) {
             $onError(1, 'test error ouput');

--- a/tests/Integration/PhpFpmTest.php
+++ b/tests/Integration/PhpFpmTest.php
@@ -8,7 +8,7 @@ use Valet\PhpFpm;
 
 class PhpFpmTest extends TestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         $_SERVER['SUDO_USER'] = user();
 
@@ -16,7 +16,7 @@ class PhpFpmTest extends TestCase
     }
 
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         exec('rm -rf ' . __DIR__ . '/output');
         mkdir(__DIR__ . '/output');
@@ -35,11 +35,11 @@ class PhpFpmTest extends TestCase
 
         resolve(StubForUpdatingFpmConfigFiles::class)->installConfiguration();
         $contents = file_get_contents(__DIR__ . '/output/valet.conf');
-        $this->assertContains(sprintf("\nuser = %s", user()), $contents);
-        $this->assertContains(sprintf("\ngroup = %s", group()), $contents);
-        $this->assertContains(sprintf("\nlisten.owner = %s", user()), $contents);
-        $this->assertContains(sprintf("\nlisten.group = %s", group()), $contents);
-        $this->assertContains("\nlisten = " . VALET_HOME_PATH . "/valet.sock", $contents);
+        $this->assertStringContainsString(sprintf("\nuser = %s", user()), $contents);
+        $this->assertStringContainsString(sprintf("\ngroup = %s", group()), $contents);
+        $this->assertStringContainsString(sprintf("\nlisten.owner = %s", user()), $contents);
+        $this->assertStringContainsString(sprintf("\nlisten.group = %s", group()), $contents);
+        $this->assertStringContainsString("\nlisten = " . VALET_HOME_PATH . "/valet.sock", $contents);
     }
 }
 
@@ -51,7 +51,7 @@ class StubForUpdatingFpmConfigFiles extends PhpFpm
         return __DIR__ . '/output';
     }
 
-    public function getVersion()
+    public function getVersion($real = false)
     {
         return '7.1';
     }

--- a/tests/Integration/RequirementsTest.php
+++ b/tests/Integration/RequirementsTest.php
@@ -7,7 +7,7 @@ use Valet\Requirements;
 
 class RequirementsTest extends TestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         $_SERVER['SUDO_USER'] = user();
 
@@ -15,7 +15,7 @@ class RequirementsTest extends TestCase
     }
 
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         Mockery::close();
     }

--- a/tests/Integration/SiteTest.php
+++ b/tests/Integration/SiteTest.php
@@ -8,7 +8,7 @@ use Valet\Site;
 
 class SiteTest extends TestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         $_SERVER['SUDO_USER'] = user();
 
@@ -16,7 +16,7 @@ class SiteTest extends TestCase
     }
 
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         exec('rm -rf ' . __DIR__ . '/output');
         mkdir(__DIR__ . '/output');
@@ -48,11 +48,11 @@ class SiteTest extends TestCase
         symlink(__DIR__ . '/output/file.out', __DIR__ . '/output/link');
         $site = resolve(StubForRemovingLinks::class);
         $site->unlink('link');
-        $this->assertFileNotExists(__DIR__ . '/output/link');
+        $this->assertFileDoesNotExist(__DIR__ . '/output/link');
 
         $site = resolve(StubForRemovingLinks::class);
         $site->unlink('link');
-        $this->assertFileNotExists(__DIR__ . '/output/link');
+        $this->assertFileDoesNotExist(__DIR__ . '/output/link');
     }
 
 
@@ -63,7 +63,7 @@ class SiteTest extends TestCase
         unlink(__DIR__ . '/output/file.out');
         $site = resolve(StubForRemovingLinks::class);
         $site->pruneLinks();
-        $this->assertFileNotExists(__DIR__ . '/output/link');
+        $this->assertFileDoesNotExist(__DIR__ . '/output/link');
     }
 }
 


### PR DESCRIPTION
This PR will add missing compatibility to tests, especially, on `setUp` and `tearDown` functions to be:
```diff
-    protected function setUp()
+    protected function setUp(): void

-    protected function tearDown()
+    protected function tearDown(): void
```

Also, will change deprecated mockery function `assertFileNotExists()` to `assertFileDoesNotExist()` and fix some tests as will.
