### PR TITLE
Exclude entire loopback range from DNS file

### DIFF
--- a/cli/stubs/valet-dns
+++ b/cli/stubs/valet-dns
@@ -58,7 +58,7 @@ function updateNameservers() {
     echo "${FILES[@]}" | tee "${WORKDIR}/resolvfiles.log" &>/dev/null
 
     cat "$DNSHEAD" | unique | tee "$DNSFILE" &>/dev/null
-    cat "${FILES[@]}" | grep -i '^nameserver' | grep -vE '127\.((0\.){2}([1-9]|[1-9]\d|[12]\d\d)|0\.([1-9]|[1-9]\d|[12]\d\d)\.([1-9]?\d|[12]\d\d)|(255\.){2}([1-9]?\d|1\d\d|2[0-4]\d|25[0-4])|255\.([1-9]?\d|1\d\d|2[0-4]\d|25[0-4])\.([1-9]?\d|[12]\d\d)|([1-9]|[1-9]\d|1\d\d|2[0-4]\d|25[0-4])(\.([1-9]?\d|[12]\d\d)){2})' | unique | tee -a "$DNSFILE" &>/dev/null
+    cat "${FILES[@]}" | grep -i '^nameserver' | grep -vE '127\.(0\.){2}\d{1,3}' | unique | tee -a "$DNSFILE" &>/dev/null
 
     symlinkResolv
 

--- a/cli/stubs/valet-dns
+++ b/cli/stubs/valet-dns
@@ -58,7 +58,7 @@ function updateNameservers() {
     echo "${FILES[@]}" | tee "${WORKDIR}/resolvfiles.log" &>/dev/null
 
     cat "$DNSHEAD" | unique | tee "$DNSFILE" &>/dev/null
-    cat "${FILES[@]}" | grep -i '^nameserver' | grep -v '127.0.0.1' | unique | tee -a "$DNSFILE" &>/dev/null
+    cat "${FILES[@]}" | grep -i '^nameserver' | grep -vE '127\.((0\.){2}([1-9]|[1-9]\d|[12]\d\d)|0\.([1-9]|[1-9]\d|[12]\d\d)\.([1-9]?\d|[12]\d\d)|(255\.){2}([1-9]?\d|1\d\d|2[0-4]\d|25[0-4])|255\.([1-9]?\d|1\d\d|2[0-4]\d|25[0-4])\.([1-9]?\d|[12]\d\d)|([1-9]|[1-9]\d|1\d\d|2[0-4]\d|25[0-4])(\.([1-9]?\d|[12]\d\d)){2})' | unique | tee -a "$DNSFILE" &>/dev/null
 
     symlinkResolv
 


### PR DESCRIPTION
Hi,
With my Ubuntu 20.04 install, 127.0.0.53 was included in one of the resolv files valet-dns scrapes when looking for nameservers.

I believe this IP, like 127.0.0.1, should be excluded to prevent slow DNS lookups due to an infinite loop lookup (until a timeout occurs).

This change will exclude the entire loopback range, instead of just 127.0.0.1.

Thanks for considering this pull.

Cheers