### PR TITLE
bump version

### DIFF
--- a/cli/valet.php
+++ b/cli/valet.php
@@ -18,7 +18,7 @@ use Silly\Application;
  */
 Container::setInstance(new Container);
 
-$version = 'v2.2.32';
+$version = 'v2.2.36';
 
 $app = new Application('Valet', $version);
 


### PR DESCRIPTION
Hey @Adesin-fr 

The current release is `v2.2.35` now prefixed with `v`, but the Version wasn't bumped in the code itself so the `valet update` command still tries to update every time.

![image](https://user-images.githubusercontent.com/13331388/195258272-85a34d10-5fdb-45ec-9994-e6b85c80192c.png)

Please merge this and release `v2.2.36` and keep in mind to bump the version before each release.

Cheers Adrian.