### PR TITLE
fix isolate

### DIFF
--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -338,7 +338,15 @@ class Site
 
             $url = ($secured ? 'https' : 'http') . '://' . $site . '.' . $config['domain'] . ($secured ? $httpsPort : $httpPort);
 
-            return [$site, $secured ? ' X' : '', $url, $path];
+            $phpVersion = $this->getPhpVersion($site . '.' . $config['domain']);
+
+            return [
+                'site' => $site,
+                'secured' => $secured ? ' X' : '',
+                'url' => $url,
+                'path' => $path,
+                'phpVersion' => $phpVersion,
+            ];
         });
     }
 

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -16,7 +16,7 @@ use Silly\Application;
 /**
  * Create the application.
  */
-Container::setInstance(new Container);
+Container::setInstance(new Container());
 
 $version = 'v2.2.37';
 
@@ -65,7 +65,8 @@ if (is_dir(VALET_HOME_PATH)) {
         }
 
         DnsMasq::updateDomain(
-            $oldDomain = Configuration::read()['domain'], $domain = trim($domain, '.')
+            $oldDomain = Configuration::read()['domain'],
+            $domain = trim($domain, '.')
         );
 
         Configuration::updateKey('domain', $domain);
@@ -165,7 +166,7 @@ if (is_dir(VALET_HOME_PATH)) {
     $app->command('links', function () {
         $links = Site::links();
 
-        table(['Site', 'SSL', 'URL', 'Path'], $links->all());
+        table(['Site', 'SSL', 'URL', 'Path', 'PHP'], $links->all());
     })->descriptions('Display all of the registered Valet links');
 
     /**
@@ -390,7 +391,6 @@ if (is_dir(VALET_HOME_PATH)) {
 
         table(['Path', 'PHP Version'], $sites->all());
     })->descriptions('List all sites using isolated versions of PHP.');
-
 }
 
 

--- a/tests/Integration/PhpFpmTest.php
+++ b/tests/Integration/PhpFpmTest.php
@@ -12,7 +12,7 @@ class PhpFpmTest extends TestCase
     {
         $_SERVER['SUDO_USER'] = user();
 
-        Container::setInstance(new Container);
+        Container::setInstance(new Container());
     }
 
 
@@ -46,7 +46,7 @@ class PhpFpmTest extends TestCase
 
 class StubForUpdatingFpmConfigFiles extends PhpFpm
 {
-    public function fpmConfigPath()
+    public function fpmConfigPath($phpVersion = null)
     {
         return __DIR__ . '/output';
     }


### PR DESCRIPTION
`getLinks()` now returns the same data structure as `getSites()` and can be used together to find a site to isolate (the `->where('site', $site)` didn't find links)

`PhpFpmTest::test_install_configuration_replaces_user_and_sock_in_config_file` doesn't pass but I think is not related to my edits.