### PR TITLE
Bug fix valet (host-header) - fixed problems with 'valet share'

### DIFF
--- a/valet
+++ b/valet
@@ -96,7 +96,7 @@ then
 
     # Fetch Ngrok URL In Background...
     bash "$DIR/cli/scripts/fetch-share-url.sh" &
-    sudo -u $USER "$DIR/bin/ngrok" http "$HOST.$DOMAIN:$PORT" -host-header=rewrite ${*:2}
+    sudo -u $USER "$DIR/bin/ngrok" http "$HOST.$DOMAIN:$PORT" --host-header=rewrite ${*:2}
     exit
 
 # Finally, for every other command we will just proxy into the PHP tool


### PR DESCRIPTION
There was a problem with "Valet share" on my debian 11.

![hostheader](https://user-images.githubusercontent.com/32018586/211843922-1dcb26ed-3bce-4b71-acbb-904e46ea0653.png)

I saw the code has a bug :
![vscode](https://user-images.githubusercontent.com/32018586/211844015-25bf9c4d-90c4-4b8b-8868-59fe2e61e8c8.png)

It was missing a dash.Fixed it
![fix](https://user-images.githubusercontent.com/32018586/211844083-3b981a1e-9884-48d9-ad50-808de22c0fad.png)

Now valet share is working.

I think this was a typo in the code so that many are facing problems with valet share.

Did I do the correct thing ?

