### PR TITLE
Revert package name in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "adesin-fr/valet-linux-ng",
+    "name": "cpriego/valet-linux",
     "description": "A more enjoyable local development experience for Linux.",
     "keywords": ["laravel", "zonda", "wwdhhd", "ubuntu", "fedora", "arch", "linux", "valet"],
     "license": "MIT",


### PR DESCRIPTION
I guess the change in the package name was changed unintentionally.

I noticed it as I keep a local fork with some patches and composer wasn't respecting the "repositories" property, and was trying to download from packagist instead.