### PR TITLE
Fix #383

### DIFF
--- a/cli/Valet/DnsMasq.php
+++ b/cli/Valet/DnsMasq.php
@@ -85,7 +85,6 @@ class DnsMasq
 
         $this->files->backup($this->resolvconf);
         $this->files->unlink($this->resolvconf);
-        $this->files->symlink($script, $this->resolvconf);
 
         return true;
     }


### PR DESCRIPTION
The symlinking of an executable shell script to a resolv.conf file seems to make little sense; in any case it made it impossible for the valet-dns service to start.