### PR TITLE
Fixes call of non-static method called statically. resolves #406

### DIFF
--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -6,6 +6,7 @@ use DomainException;
 use Valet\Contracts\PackageManager;
 use Valet\PackageManagers\Homebrew;
 use Valet\Contracts\ServiceManager;
+use Valet\PackageManagers\Dnf;
 
 class PhpFpm
 {
@@ -403,15 +404,8 @@ class PhpFpm
      */
     public static function fpmSockName($phpVersion = null)
     {
-        if (!$phpVersion) {
-            $phpVersion = self::getPhpVersion();
-        }
 
         $versionInteger = preg_replace('~[^\d]~', '', $phpVersion);
-
-        if (!$versionInteger) {
-
-        }
 
         return "valet{$versionInteger}.sock";
     }
@@ -520,9 +514,14 @@ class PhpFpm
 
     public function getPhpVersion()
     {
+        if ($this->pm instanceof Dnf) {
+            return null;
+        }
+
         if (!$this->version) {
             $this->version = $this->normalizePhpVersion(PHP_VERSION);
         }
+
         return $this->version;
     }
 }


### PR DESCRIPTION
Version is always given before calling fpmSockName(), no need to force resolve it again if it was not passed or was null. DNF doesn't support package versioning in a "traditional" way. @see https://docs.fedoraproject.org/en-US/modularity/using-modules/
resolves #406