### PR TITLE
Fix - Dependencies Conflict With Laravel Installer 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
     },
     "require": {
         "php": ">=7.0",
-        "illuminate/container": "~5.3|^6.0|^7.0|^8.0|^9.0",
+        "illuminate/container": "~5.3|^6.0|^7.0|^8.0|^9.0|^10.0",
         "mnapoli/silly": "~1.1",
         "symfony/process": "~2.7|~3.0|~4.0|~5.0|^6.0",
         "nategood/httpful": "~0.2",


### PR DESCRIPTION
Laravel Installer 5 include the laravel/prompts which require at least v10 of illuminate/collection

https://github.com/laravel/prompts/blob/a73492017025c906f844dc9a3489b013c7e1f659/composer.json#L21C25-L21C25