### PR TITLE
if version is null the get the php fpm version first which fix the do…

### DIFF
--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -379,7 +379,7 @@ class PhpFpm
 
         return $version;
     }
-    
+
     /**
      * Get the possible PHP FPM service names.
      *
@@ -387,6 +387,9 @@ class PhpFpm
      */
     public function getFpmServiceNames()
     {
+        if(is_null($this->version)) {
+            $this->version = $this->getPhpVersion();
+        }
         return [
             "php-fpm",
             "php-fpm{$this->version}",
@@ -417,7 +420,7 @@ class PhpFpm
 
         return new DomainException('Unable to determine PHP service name.');
     }
-    
+
     /**
      * Get FPM sock file name for a given PHP version.
      *


### PR DESCRIPTION
for some reason when i upgrade the laravel installer to 5.0 on ubuntu 22.04 i get the error when the run 
`valet stop` or `status` and i was due the PHP version would be null so now if your PHP version is null when we stop the error we get the PHP version  which seem to fix the error