### PR TITLE
Remove Abandoned Package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,11 +46,11 @@
     },
     "require": {
         "php": ">=7.0",
+        "illuminate/collections": "^8.0|^9.0|^10.0",
         "illuminate/container": "~5.3|^6.0|^7.0|^8.0|^9.0|^10.0",
         "mnapoli/silly": "~1.1",
         "symfony/process": "~2.7|~3.0|~4.0|~5.0|^6.0",
         "nategood/httpful": "~0.2",
-        "tightenco/collect": "~5.3|^6.0|^7.0|^8.0|^9.0",
         "ext-posix": "*",
         "ext-json": "*",
         "outrightvision/api-model": "^1.0"


### PR DESCRIPTION
tightenco/collect package is abandoned and no longer maintained. The author suggests using the [illuminate/collections](https://packagist.org/packages/illuminate/collections) package instead.