### PR TITLE
Fix namespace issues in drivers for better compatibility with Linux

### DIFF
--- a/cli/drivers/BasicValetDriver.php
+++ b/cli/drivers/BasicValetDriver.php
@@ -1,4 +1,5 @@
 <?php
+namespace Valet\Drivers;
 
 class BasicValetDriver extends ValetDriver
 {

--- a/cli/drivers/BedrockValetDriver.php
+++ b/cli/drivers/BedrockValetDriver.php
@@ -1,4 +1,5 @@
 <?php
+namespace Valet\Drivers;
 
 class BedrockValetDriver extends BasicValetDriver
 {

--- a/cli/drivers/Cake2ValetDriver.php
+++ b/cli/drivers/Cake2ValetDriver.php
@@ -1,4 +1,5 @@
 <?php
+namespace Valet\Drivers;
 
 class Cake2ValetDriver extends ValetDriver
 {

--- a/cli/drivers/CakeValetDriver.php
+++ b/cli/drivers/CakeValetDriver.php
@@ -1,4 +1,5 @@
 <?php
+namespace Valet\Drivers;
 
 class CakeValetDriver extends ValetDriver
 {

--- a/cli/drivers/Concrete5ValetDriver.php
+++ b/cli/drivers/Concrete5ValetDriver.php
@@ -1,4 +1,5 @@
 <?php
+namespace Valet\Drivers;
 
 class Concrete5ValetDriver extends BasicValetDriver
 {

--- a/cli/drivers/ContaoValetDriver.php
+++ b/cli/drivers/ContaoValetDriver.php
@@ -1,4 +1,5 @@
 <?php
+namespace Valet\Drivers;
 
 class ContaoValetDriver extends ValetDriver
 {

--- a/cli/drivers/CraftValetDriver.php
+++ b/cli/drivers/CraftValetDriver.php
@@ -1,4 +1,5 @@
 <?php
+namespace Valet\Drivers;
 
 class CraftValetDriver extends ValetDriver
 {

--- a/cli/drivers/DrupalValetDriver.php
+++ b/cli/drivers/DrupalValetDriver.php
@@ -1,4 +1,5 @@
 <?php
+namespace Valet\Drivers;
 
 class DrupalValetDriver extends ValetDriver
 {

--- a/cli/drivers/JigsawValetDriver.php
+++ b/cli/drivers/JigsawValetDriver.php
@@ -1,4 +1,5 @@
 <?php
+namespace Valet\Drivers;
 
 class JigsawValetDriver extends BasicValetDriver
 {

--- a/cli/drivers/JoomlaValetDriver.php
+++ b/cli/drivers/JoomlaValetDriver.php
@@ -1,4 +1,5 @@
 <?php
+namespace Valet\Drivers;
 
 class JoomlaValetDriver extends BasicValetDriver
 {

--- a/cli/drivers/KatanaValetDriver.php
+++ b/cli/drivers/KatanaValetDriver.php
@@ -1,4 +1,5 @@
 <?php
+namespace Valet\Drivers;
 
 class KatanaValetDriver extends BasicValetDriver
 {

--- a/cli/drivers/KirbyValetDriver.php
+++ b/cli/drivers/KirbyValetDriver.php
@@ -1,4 +1,5 @@
 <?php
+namespace Valet\Drivers;
 
 class KirbyValetDriver extends ValetDriver
 {

--- a/cli/drivers/LaravelValetDriver.php
+++ b/cli/drivers/LaravelValetDriver.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Valet\Drivers;
+
 class LaravelValetDriver extends ValetDriver
 {
     /**

--- a/cli/drivers/Magento2ValetDriver.php
+++ b/cli/drivers/Magento2ValetDriver.php
@@ -1,4 +1,5 @@
 <?php
+namespace Valet\Drivers;
 
 class Magento2ValetDriver extends ValetDriver
 {

--- a/cli/drivers/NeosValetDriver.php
+++ b/cli/drivers/NeosValetDriver.php
@@ -1,4 +1,5 @@
 <?php
+namespace Valet\Drivers;
 
 class NeosValetDriver extends ValetDriver
 {

--- a/cli/drivers/SculpinValetDriver.php
+++ b/cli/drivers/SculpinValetDriver.php
@@ -1,4 +1,5 @@
 <?php
+namespace Valet\Drivers;
 
 class SculpinValetDriver extends BasicValetDriver
 {

--- a/cli/drivers/StatamicV1ValetDriver.php
+++ b/cli/drivers/StatamicV1ValetDriver.php
@@ -1,4 +1,5 @@
 <?php
+namespace Valet\Drivers;
 
 class StatamicV1ValetDriver extends ValetDriver
 {

--- a/cli/drivers/StatamicValetDriver.php
+++ b/cli/drivers/StatamicValetDriver.php
@@ -1,4 +1,5 @@
 <?php
+namespace Valet\Drivers;
 
 class StatamicValetDriver extends ValetDriver
 {

--- a/cli/drivers/SymfonyValetDriver.php
+++ b/cli/drivers/SymfonyValetDriver.php
@@ -1,4 +1,5 @@
 <?php
+namespace Valet\Drivers;
 
 class SymfonyValetDriver extends ValetDriver
 {

--- a/cli/drivers/Typo3ValetDriver.php
+++ b/cli/drivers/Typo3ValetDriver.php
@@ -1,4 +1,5 @@
 <?php
+namespace Valet\Drivers;
 
 /**
  * This driver serves TYPO3 instances (version 7.0 and up). It activates, if it

--- a/cli/drivers/ValetDriver.php
+++ b/cli/drivers/ValetDriver.php
@@ -1,5 +1,6 @@
 <?php
 
+namespace Valet\Drivers;
 abstract class ValetDriver
 {
     /**
@@ -50,29 +51,28 @@ abstract class ValetDriver
 
         $drivers = array_merge($drivers, static::driversIn(VALET_HOME_PATH . '/Drivers'));
 
-        $drivers[] = 'LaravelValetDriver';
-
-        $drivers[] = 'WordPressValetDriver';
-        $drivers[] = 'BedrockValetDriver';
-        $drivers[] = 'ContaoValetDriver';
-        $drivers[] = 'SymfonyValetDriver';
-        $drivers[] = 'CraftValetDriver';
-        $drivers[] = 'StatamicValetDriver';
-        $drivers[] = 'StatamicV1ValetDriver';
-        $drivers[] = 'CakeValetDriver';
-        $drivers[] = 'Cake2ValetDriver';
-        $drivers[] = 'SculpinValetDriver';
-        $drivers[] = 'JigsawValetDriver';
-        $drivers[] = 'KirbyValetDriver';
-        $drivers[] = 'KatanaValetDriver';
-        $drivers[] = 'JoomlaValetDriver';
-        $drivers[] = 'DrupalValetDriver';
-        $drivers[] = 'Concrete5ValetDriver';
-        $drivers[] = 'Typo3ValetDriver';
-        $drivers[] = 'NeosValetDriver';
-        $drivers[] = 'Magento2ValetDriver';
-
-        $drivers[] = 'BasicValetDriver';
+        // Adicionar o namespace completo para cada driver
+        $drivers[] = 'Valet\Drivers\LaravelValetDriver';
+        $drivers[] = 'Valet\Drivers\WordPressValetDriver';
+        $drivers[] = 'Valet\Drivers\BedrockValetDriver';
+        $drivers[] = 'Valet\Drivers\ContaoValetDriver';
+        $drivers[] = 'Valet\Drivers\SymfonyValetDriver';
+        $drivers[] = 'Valet\Drivers\CraftValetDriver';
+        $drivers[] = 'Valet\Drivers\StatamicValetDriver';
+        $drivers[] = 'Valet\Drivers\StatamicV1ValetDriver';
+        $drivers[] = 'Valet\Drivers\CakeValetDriver';
+        $drivers[] = 'Valet\Drivers\Cake2ValetDriver';
+        $drivers[] = 'Valet\Drivers\SculpinValetDriver';
+        $drivers[] = 'Valet\Drivers\JigsawValetDriver';
+        $drivers[] = 'Valet\Drivers\KirbyValetDriver';
+        $drivers[] = 'Valet\Drivers\KatanaValetDriver';
+        $drivers[] = 'Valet\Drivers\JoomlaValetDriver';
+        $drivers[] = 'Valet\Drivers\DrupalValetDriver';
+        $drivers[] = 'Valet\Drivers\Concrete5ValetDriver';
+        $drivers[] = 'Valet\Drivers\Typo3ValetDriver';
+        $drivers[] = 'Valet\Drivers\NeosValetDriver';
+        $drivers[] = 'Valet\Drivers\Magento2ValetDriver';
+        $drivers[] = 'Valet\Drivers\BasicValetDriver';
 
         foreach ($drivers as $driver) {
             $driver = new $driver;

--- a/cli/drivers/WordPressValetDriver.php
+++ b/cli/drivers/WordPressValetDriver.php
@@ -1,4 +1,5 @@
 <?php
+namespace Valet\Drivers;
 
 class WordPressValetDriver extends BasicValetDriver
 {

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -18,7 +18,7 @@ use Silly\Application;
  */
 Container::setInstance(new Container());
 
-$version = 'v2.3.8';
+$version = 'v2.3.10';
 
 $app = new Application('Valet', $version);
 


### PR DESCRIPTION
- Added the missing 'Valet\Drivers' namespace to various driver files (ValetDriver, LaravelValetDriver, BasicValetDriver, etc.)
- Ensured that all driver classes were properly referenced using their fully qualified names.
- These changes were necessary to fix compatibility issues on Linux, where the drivers were not being loaded correctly due to missing namespaces.

This improves the functionality of Valet on Linux environments and resolves class not found errors when using custom drivers.