### PR TITLE
fix proxy server issues, fix proxies list, fix links with ssl taging …

### DIFF
--- a/cli/stubs/proxy.valet.conf
+++ b/cli/stubs/proxy.valet.conf
@@ -1,8 +1,7 @@
 # valet stub: proxy.valet.conf
 
 server {
-    listen 127.0.0.1:80;
-    #listen VALET_LOOPBACK:80; # valet loopback
+    listen 80;
     server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
     root /;
     charset utf-8;
@@ -37,8 +36,7 @@ server {
 }
 
 server {
-    listen 127.0.0.1:60;
-    #listen VALET_LOOPBACK:60; # valet loopback
+    listen 60;
     server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
     root /;
     charset utf-8;

--- a/cli/stubs/secure.proxy.valet.conf
+++ b/cli/stubs/secure.proxy.valet.conf
@@ -1,15 +1,13 @@
 # valet stub: secure.proxy.valet.conf
 
 server {
-    listen 127.0.0.1:80;
-    #listen VALET_LOOPBACK:80; # valet loopback
+    listen VALET_HTTP_PORT;
     server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
     return 301 https://$host$request_uri;
 }
 
 server {
-    listen 127.0.0.1:443 ssl http2;
-    #listen VALET_LOOPBACK:443 ssl http2; # valet loopback
+    listen VALET_HTTPS_PORT ssl http2;
     server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
     root /;
     charset utf-8;


### PR DESCRIPTION
1. This patch resolves the issue with the proxy server. Previously, creating a proxy server domain would disrupt other running Valet domains.

2. The proxy domain list was not displaying correctly with the `valet proxies` command. This patch will address that issue.

3. The SSL tagging in the list was not appearing, even though SSL was applied to the domains, due to a mismatch in the $certs string. This issue has also been fixed.