### PR TITLE
Add db:setup and db:create commands for MySQL database management

### DIFF
--- a/cli/Valet/Database.php
+++ b/cli/Valet/Database.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Valet;
+
+class Database
+{
+    public $cli;
+
+    public function __construct(CommandLine $cli)
+    {
+        $this->cli = $cli;
+    }
+
+    public function setup()
+    {
+        $user = user();
+
+        $this->cli->passthru(
+            'mysql -u root -proot -e ' . escapeshellarg(
+                "CREATE USER IF NOT EXISTS '{$user}'@'localhost' IDENTIFIED VIA unix_socket; " .
+                "ALTER USER '{$user}'@'localhost' IDENTIFIED VIA unix_socket; " .
+                "GRANT ALL PRIVILEGES ON *.* TO '{$user}'@'localhost' WITH GRANT OPTION; " .
+                "FLUSH PRIVILEGES;"
+            )
+        );
+
+        info("Passwordless MySQL access configured for user '{$user}'.");
+    }
+
+    public function create($name)
+    {
+        $this->cli->passthru(
+            'mysql -e ' . escapeshellarg("CREATE DATABASE IF NOT EXISTS `{$name}` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;")
+        );
+
+        info("Database '{$name}' created successfully.");
+    }
+}

--- a/cli/includes/facades.php
+++ b/cli/includes/facades.php
@@ -96,3 +96,7 @@ class Valet extends Facade
 class Requirements extends Facade
 {
 }
+
+class Database extends Facade
+{
+}

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -458,6 +458,23 @@ if (is_dir(VALET_HOME_PATH)) {
 
 
 /**
+ * Database commands.
+ */
+$app->command('db:setup', function () {
+    Database::setup();
+
+    info('MySQL is ready to use.');
+
+    return 0;
+})->descriptions('Configure MySQL for passwordless root access');
+
+$app->command('db:create name', function ($name) {
+    Database::create($name);
+
+    return 0;
+})->descriptions('Create a new MySQL database');
+
+/**
  * Load all of the Valet extensions.
  */
 foreach (Valet::extensions() as $extension) {


### PR DESCRIPTION
## Summary

Add two new Valet commands for managing MySQL databases locally.

## Commands

### `valet db:setup`
Configures passwordless MySQL access for the current system user by creating them in MySQL with `unix_socket` authentication and granting all privileges.

### `valet db:create <name>`
Creates a new MySQL database with `utf8mb4` charset and `utf8mb4_unicode_ci` collation.

## Usage

```bash
# Run once to enable passwordless access
valet db:setup

# Create a database from any project directory
valet db:create my_database
