### PR TITLE
fix(deps): replace abandoned tightenco/collect and add support for Symfony 8 & Illuminate 13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,11 +46,11 @@
     },
     "require": {
         "php": ">=7.0",
-        "illuminate/container": "~5.3|^6.0|^7.0|^8.0|^9.0|^10.0|^11.00|^12.00",
+        "illuminate/container": "~5.3|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
         "mnapoli/silly": "~1.1",
-        "symfony/process": "~2.7|~3.0|~4.0|~5.0|^6.0|^7.0",
+        "symfony/process": "~2.7|~3.0|~4.0|~5.0|^6.0|^7.0|^8.0",
         "nategood/httpful": "~1.0",
-        "tightenco/collect": "~5.3|^6.0|^7.0|^8.0|^9.0",
+        "illuminate/collections": "~5.8|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
         "ext-posix": "*",
         "ext-json": "*",
         "outrightvision/api-model": "^1.0"


### PR DESCRIPTION
## Summary

- **Replace tightenco/collect**: Replaced the abandoned `tightenco/collect` package with the official `illuminate/collections` package.
- **Add Symfony 8 support**: Updated `symfony/process` constraint to `~2.7|~3.0|~4.0|~5.0|^6.0|^7.0|^8.0`.
- **Add Illuminate 13 support**: Extended `illuminate/container` and `illuminate/collections` constraints to include `^13.0`.

## Motivation

Installing `cpriego/valet-linux` in modern environments (with PHP 8.3/8.4 and global composer packages using Symfony 8 / Illuminate 13) failed due to missing version bounds and abandoned dependencies.

## Verification

- Ran test suite (`./vendor/bin/phpunit`): 40/40 tests passing (100%).
- Verified `composer update` and global installation (`composer global require cpriego/valet-linux`).